### PR TITLE
Display generate token buttons when key generation is successful

### DIFF
--- a/src/pages/application/partials/generate-oauth-key.hbs
+++ b/src/pages/application/partials/generate-oauth-key.hbs
@@ -66,8 +66,7 @@
                         </div>
                     </div>
 
-                    {{#if (contains keys.supportedGrantTypes "client_credentials")}}
-                    <div class="d-flex mb-4">
+                    <div id="tokenGenerationButtons_{{../name}}" class="d-flex mb-4" style="{{#unless (contains keys.supportedGrantTypes 'client_credentials')}} display: none !important;{{/unless}}">
                         <div class="row">
                             <div class="d-flex gap-2 mb-3">
                                 <button class='common-btn-primary'
@@ -139,7 +138,6 @@
                             </div>
                         </div>
                     </div>
-                    {{/if}}
 
                     <div id="KMURl_{{../name}}" style="{{#unless keys.consumerKey}}display: none;{{/unless}}">
                         <div id="header">
@@ -313,6 +311,16 @@
                                 </div>
                             </div>
                         </form>
+                        <!-- Add Update configuration button when consumer key exists -->
+                        <div class="d-flex mt-4 mb-3" id="applicationKeyUpdateButtonContainer"
+                            style="{{#unless keys.consumerKey}}display: none !important;{{/unless}}">
+                            <button class="common-btn-primary" id="applicationKeyUpdateButton" name="http-values"
+                                type="button" onClick="updateApplicationKey('applicationKeyGenerateForm-{{../id}}-{{#if ../../isProduction}}production{{else}}sandbox{{/if}}',
+                                   '{{json ../../applicationMetadata.appMap}}', {{#if ../../isProduction}}'PRODUCTION'{{else}}'SANDBOX'{{/if}}, '{{../name}}',
+                                   '{{keys.keyMappingId}}', '{{keys.clientName}}')">
+                                Update
+                            </button>
+                        </div>
                     </div>
                     {{else}}
                     <div class="key-action-container" id="key-action-container">
@@ -465,23 +473,23 @@
                                     </div>
                                 </div>
                             </form>
+
+                            <!-- Add Update button at the bottom only when consumer key exists -->
+                            <div class="d-flex mt-4 mb-3" id="applicationKeyUpdateButtonContainer"
+                                style="{{#unless keys.consumerKey}}display: none !important;{{/unless}}">
+                                <button class="common-btn-primary" id="applicationKeyUpdateButton" name="http-values"
+                                    type="button" onClick="updateApplicationKey('applicationKeyGenerateForm-{{../id}}-{{#if ../../isProduction}}production{{else}}sandbox{{/if}}',
+                                   '{{json ../../applicationMetadata.appMap}}', {{#if ../../isProduction}}'PRODUCTION'{{else}}'SANDBOX'{{/if}}, '{{../name}}',
+                                   '{{keys.keyMappingId}}', '{{keys.clientName}}')">
+                                    Update
+                                </button>
+                            </div>
                         </div>
                     </div>
 
                     {{!-- Place to show the advanced configurations when the key generation is successful --}}
                     <div id="advanced-config-placeholder"></div>
-                    {{/if}}
 
-                    {{#if keys.consumerKey}}
-                    <!-- Add Update button at the bottom only when consumer key exists -->
-                    <div class="d-flex justify-content-end mt-4 mb-3">
-                        <button class="common-btn-primary" id="applicationKeyUpdateButton" name="http-values"
-                            type="button" onClick="updateApplicationKey('applicationKeyGenerateForm-{{../id}}-{{#if ../../isProduction}}production{{else}}sandbox{{/if}}',
-                                   '{{json ../../applicationMetadata.appMap}}', {{#if ../../isProduction}}'PRODUCTION'{{else}}'SANDBOX'{{/if}}, '{{../name}}',
-                                   '{{keys.keyMappingId}}', '{{keys.clientName}}')">
-                            Update
-                        </button>
-                    </div>
                     {{/if}}
 
                     {{/let}}

--- a/src/scripts/oauth2-key-generation.js
+++ b/src/scripts/oauth2-key-generation.js
@@ -68,6 +68,32 @@ async function generateApplicationKey(formId, appId, keyType, keyManager, client
                 advancedConfigButton.style.display = "flex";
             }
 
+            // Show the token generation buttons
+            const tokenGenerationButtons = document.getElementById("tokenGenerationButtons_" + keyManager);
+            if (tokenGenerationButtons) {
+                tokenGenerationButtons.style.display = "flex";
+                
+                // Get the generate token button and update its onClick handler with correct values
+                const generateTokenButton = tokenGenerationButtons.querySelector(`#apiKeyGenerateButton-${keyType.toLowerCase()}`);
+                if (generateTokenButton) {
+                    generateTokenButton.setAttribute("onClick", 
+                        `generateOauthKey('${formId}', '${responseData.appRefId}', '${responseData.keyMappingId}', '${keyManager}', '${clientName}')`);
+                }
+            }
+
+            // Show the update button container
+            const updateButtonContainer = document.getElementById("applicationKeyUpdateButtonContainer");
+            if (updateButtonContainer) {
+                updateButtonContainer.style.display = "flex";
+                
+                // Get the update button and set its onClick handler with the correct appRefID
+                const updateButton = document.getElementById("applicationKeyUpdateButton");
+                if (updateButton) {
+                    updateButton.setAttribute("onClick", 
+                        `updateApplicationKey('${formId}', '${JSON.stringify([{appRefID: responseData.appRefId}])}', '${keyType}', '${keyManager}', '${responseData.keyMappingId}', '${clientName}')`);
+                }
+            }
+
             const KMURLs = document.getElementById("KMURl_" + keyManager);
             KMURLs.style.display = "block";
         } else {

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -868,6 +868,9 @@ const createAppKeyMapping = async (req, res) => {
             tokenDetails.keyType = "SANDBOX"
             //generate oauth key
             responseData = await invokeApiRequest(req, 'POST', `${controlPlaneUrl}/applications/${cpAppID}/generate-keys`, {}, tokenDetails);
+            
+            // Add the appRefId to the response data
+            responseData.appRefId = cpAppID;
         });
         return res.status(200).json(responseData);
     } catch (error) {


### PR DESCRIPTION
## Purpose
Displaying the token generation and update buttons when the key generation is successful

## Goals
Improving UX

## Approach
Moved the update button into the advanced configs since other fields are not editable
Added appRefId to the key generation response
When the key generation is successful, update the relavant `onclick` functions with the appRefId

## Samples
https://github.com/user-attachments/assets/437ab4db-cf5e-48cc-9b4b-c12f09c8e1ae
