### PR TITLE
Implement the new API subscription flow on the API page

### DIFF
--- a/src/defaultContent/pages/api-landing/partials/api-subscription-plans.hbs
+++ b/src/defaultContent/pages/api-landing/partials/api-subscription-plans.hbs
@@ -36,7 +36,7 @@
                                 <input type="hidden" id="selectedAppId-{{policyID}}" value="" />
                                 <div class="custom-select-container">
                                     <div class="select-selected" aria-expanded="false">
-                                        <span class="selected-text">Select Application</span>
+                                        <span class="selected-text">Select an app</span>
                                         <span class="select-arrow"></span>
                                     </div>
                                     <div class="select-items" role="listbox">

--- a/src/defaultContent/pages/api-landing/partials/api-subscription-plans.hbs
+++ b/src/defaultContent/pages/api-landing/partials/api-subscription-plans.hbs
@@ -24,7 +24,7 @@
         {{/if}}
         <div class="row row-gap-4 justify-content-center">
             {{#each subscriptionPlans}}
-            <div class="col-lg-3 col-md-6 col-12">
+            <div class="col-lg-3 col-md-6 col-12" id="subscriptionCard-{{policyID}}">
                 <div class="card dev-card subscription-card">
                     <div class="card-body align-items-center text-center p-0">
                         <span class="subscription-plans-card-title">{{displayName}}</span>
@@ -32,33 +32,38 @@
                         <p class="subscription-plans-card-subtitle pt-0">requests per minute</p>
                         {{#if ../isAuthenticated}}
                         <div id="subscriptionBox" class="subscription-container">
-                            <a type="button" class="common-btn-primary subscription-plan-subscribe-btn">
-                                Subscribe
-                            </a>
-                            <div class="custom-dropdown">
+                            <div class="custom-dropdown show" id="customDropdown-{{policyID}}">
+                                <input type="hidden" id="selectedAppId-{{policyID}}" value="" />
                                 <div class="custom-select-container">
                                     <div class="select-selected" aria-expanded="false">
                                         <span class="selected-text">Select Application</span>
                                         <span class="select-arrow"></span>
                                     </div>
                                     <div class="select-items" role="listbox">
-                                        <div class="select-action-item" role="button" data-action="create-app">
-                                            + Create Application</div>
-                                        {{#each ../applications}}
-                                        <div class="select-item {{#if subscribed}}disabled{{/if}}" role="button"
-                                            data-value="{{../id}}" {{#unless subscribed}} onclick="subscribe('{{@root.orgID}}', '{{id}}', '{{../../apiMetadata.apiID}}', '{{../../apiMetadata.apiReferenceID}}', '{{../policyID}}', '{{../policyName}}'
-                                            )" {{/unless}}>
-
-                                            {{name}}
-                                            {{#if subscribed}}
-                                            <img src="https://raw.githubusercontent.com/wso2/docs-bijira/refs/heads/main/en/devportal-theming/success-rounded.svg"
-                                                alt="Subscribed" class="subscription-icon" />
-                                            {{/if}}
+                                        <div class="select-search-container">
+                                            <input type="text" class="select-search-input" placeholder="Find or create an application..."
+                                                aria-label="Search applications">
                                         </div>
-                                        {{/each}}
+                                        <div class="select-items-container">
+                                            {{#each ../applications}}
+                                            <div class="select-item {{#if subscribed}}disabled{{/if}}" role="option" data-value="{{id}}" data-app-name="{{name}}">
+                                                {{name}}
+                                                {{#if subscribed}}<img src="https://raw.githubusercontent.com/wso2/docs-bijira/refs/heads/main/en/devportal-theming/success-rounded.svg" alt="Subscribed"
+                                                        class="subscription-icon" />{{/if}}
+                                            </div>
+                                            {{/each}}
+                                        </div>
+                                        <div class="create-app-container" style="display: none;">
+                                            <div class="create-app-option" role="button">
+                                                Create application "<span class="search-term"></span>"
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
+                            <a id="subscribe-btn-{{policyID}}" type="button"
+                                 class="common-btn-primary"
+                                 onclick="showSubscribeButtonLoading(this); subscribe('{{@root.orgID}}', '', '{{../apiMetadata.apiID}}', '{{../apiMetadata.apiReferenceID}}', '{{policyID}}', '{{policyName}}')">Subscribe</a>
                         </div>
                         {{else}}
                         <a type="button" class="common-btn-primary disabled w-100 subscription-plan-subscribe-btn"

--- a/src/defaultContent/pages/apis/partials/api-listing.hbs
+++ b/src/defaultContent/pages/apis/partials/api-listing.hbs
@@ -79,12 +79,12 @@
             </div>
           </div>
           {{#if ../isAuthenticated}}
-          <hr class="mx-3 my-0" />
+          <hr class="card-separator" />
           {{/if}}
           <div class="api-card-footer">
             <div id="btnSection" class="d-flex align-items-center gap-2 w-100">
               {{#if ../isAuthenticated}}
-              <div id="subscriptionBox" class="subscription-container subscription-box w-100">
+              <div id="subscriptionBox" class="subscription-container w-100">
                 {{> subscription-plans apiInfo=apiInfo apiName=apiInfo.apiName}}
                 {{#if subscriptionPolicies.length}}
 
@@ -116,7 +116,7 @@
                       </div>
                       <div class="create-app-container" style="display: none;">
                         <div class="create-app-option" role="button">
-                          Create application "<span class="search-term"></span>" and Subscribe
+                          Create application "<span class="search-term"></span>"
                         </div>
                       </div>
                     </div>
@@ -128,7 +128,7 @@
                    onclick="showSubscribeButtonLoading(this); subscribe('{{../orgID}}', '', '{{apiID}}', '{{apiReferenceID}}', '{{lookup (lookup subscriptionPolicyDetails 0) "policyID"}}', '{{lookup (lookup subscriptionPolicyDetails 0) "policyName"}}')"
                    disabled>Subscribe</a>
                  {{else}}
-                 <a type="button" class="common-btn-primary" onclick="showSubscribeButtonLoading(this); loadModal('planModal-{{apiID}}')" disabled>Subscribe</a>
+                 <a type="button" class="common-btn-primary" onclick="loadModal('planModal-{{apiID}}')" disabled>Subscribe</a>
                  {{/if}}
 
                 {{/if}}

--- a/src/defaultContent/pages/apis/partials/subscription-plans.hbs
+++ b/src/defaultContent/pages/apis/partials/subscription-plans.hbs
@@ -54,9 +54,9 @@
                                     <span class="subscription-plans-card-title">{{displayName}}</h5>
                                     <h1 class="subscription-plans-request-count">{{requestCount}}</h1>
                                     <p class="subscription-plans-card-subtitle pb-4 pt-0">requests per minutes</p>
-                                    <a id="subscribe-btn-{{../apiID}}" type="button"
+                                    <a id="subscribe-btn-{{policyID}}" type="button"
                                         class="common-btn-outlined p-1 ps-2 pe-2 w-100 subscription-plan-subscribe-btn"
-                                        onclick="subscribe('{{@root.orgID}}', '', '{{../apiID}}', '{{../apiReferenceID}}', '{{policyID}}', '{{policyName}}')">Subscribe</a>
+                                        onclick="showSubscribeButtonLoading(this); subscribe('{{@root.orgID}}', '', '{{../apiID}}', '{{../apiReferenceID}}', '{{policyID}}', '{{policyName}}')">Subscribe</a>
                                 </div>
                             </div>
                         </div>

--- a/src/defaultContent/pages/home/partials/home.hbs
+++ b/src/defaultContent/pages/home/partials/home.hbs
@@ -21,7 +21,7 @@
         <div class="hero-content hero">
             <div class="row align-items-center justify-content-between">
                 <!-- Left Content -->
-                <div class="col-lg-8 col-md-12 text-lg-start">
+                <div class="col-lg-9 col-md-12 text-lg-start">
                     <h1 class="hero-title">
                         Empower your development with our <span class="span-highlight"> APIs </span>
                         to craft intuitive and robust applications

--- a/src/defaultContent/styles/api-listing.css
+++ b/src/defaultContent/styles/api-listing.css
@@ -325,16 +325,22 @@ hr {
 }
 
 .api-card {
+  .card-separator {
+    margin: 0rem 1.25rem;
+  }
+
   .subscription-container {
-    padding: 8px;
+    padding: 8px 0px;
     margin-top: -8px;
     margin-bottom: -8px;
+    display: flex;
+    gap: 1rem;
+    width: 100%;
   }
 
   .subscription-box-label {
     font-size: 0.75rem;
     color: var(--main-text-color);
-    margin-left: 0.5rem;
     display: block;
     align-self: center;
   }
@@ -342,14 +348,6 @@ hr {
   .custom-dropdown {
     font-size: small;
     position: relative;
-    width: 100%;
-  }
-
-  .subscription-box {
-    border-radius: 1rem;
-    background-color: #f8f9fa;
-    display: flex;
-    gap: 1rem;
     width: 100%;
   }
 

--- a/src/defaultContent/styles/main.css
+++ b/src/defaultContent/styles/main.css
@@ -59,7 +59,7 @@ html {
   flex: 1;
   margin-top: 4rem;
   font-weight: 500;
-  margin-bottom: 2rem;
+  margin-bottom: 4rem;
   position: relative;
   overflow-x: hidden;
 }

--- a/src/defaultContent/styles/subscription.css
+++ b/src/defaultContent/styles/subscription.css
@@ -3,25 +3,12 @@
   /* Custom Dropdown styling for subscription plans */
   .subscription-container {
     padding: 8px;
-  }
-
-  .custom-dropdown {
-    display: none;
-    font-size: small;
-    position: relative;
-    width: 100%;
-  }
-
-  .subscription-box {
-    border-radius: 1rem;
-    background-color: #f8f9fa;
     display: flex;
     gap: 1rem;
     width: 100%;
   }
 
   .custom-dropdown {
-    display: none;
     font-size: small;
     position: relative;
     width: 100%;
@@ -68,6 +55,51 @@
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   }
 
+  /* Search container styling */
+  .select-search-container {
+    padding: 8px;
+    border-bottom: 1px solid #dee2e6;
+    position: sticky;
+    top: 0;
+    background-color: var(--main-bg-color);
+    z-index: 2;
+  }
+
+  .select-search-input {
+    width: 100%;
+    padding: 6px 8px;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    font-size: 0.75rem;
+  }
+
+  .select-search-input:focus {
+    outline: none;
+    border-color: var(--primary-main-color);
+    box-shadow: 0 0 0 2px rgba(var(--primary-main-color-rgb), 0.25);
+  }
+
+  .select-items-container {
+    max-height: 150px;
+    overflow-y: auto;
+  }
+
+  .create-app-container {
+    border-top: 1px solid #dee2e6;
+  }
+
+  .create-app-option {
+    padding: 8px 10px;
+    cursor: pointer;
+    font-size: 0.75rem;
+    color: var(--primary-main-color);
+    font-weight: 500;
+  }
+
+  .create-app-option:hover {
+    background-color: #f8f9fa;
+  }
+
   .select-item {
     padding: 8px 10px;
     cursor: pointer;
@@ -89,19 +121,6 @@
 
   .select-item.disabled:hover {
     background-color: #f0f0f0;
-  }
-
-  .select-action-item {
-    padding: 8px 10px;
-    cursor: pointer;
-    font-size: 0.7rem;
-    border-top: 1px solid #dee2e6;
-    color: var(--primary-main-color);
-    font-weight: 500;
-  }
-
-  .select-action-item:hover {
-    background-color: #f8f9fa;
   }
 
   .select-items.show {

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -186,18 +186,59 @@ document.addEventListener("DOMContentLoaded", function () {
             
             // Select first non-subscribed app by default
             const selectFirstAvailableApp = () => {
-                //check if url queyr params has app id
+                // Check if url query params has app ID
                 let params = new URLSearchParams(window.location.search);
-                let appId, appName = "";
-                // Get application data
-                // if (params.has('appID')) {
-                //      appId = params.get('appID');
-                //      appName  = params.get('appName');
-                // }
+                let appId = "";
+                let appFromParams = false;
+                
+                // Get application ID from URL parameters if available
+                if (params.has('appID')) {
+                    appId = params.get('appID');
+                    appFromParams = true;
+                }
+                
+                // If we have an app ID from params, try to find and select that app
+                if (appFromParams && appId) {
+                    const appItem = dropdown.querySelector(`.select-item[data-value="${appId}"]`);
+                    if (appItem) {
+                        const appName = appItem.getAttribute("data-app-name");
+                        // Update hidden input with selected app ID
+                        const hiddenField = document.getElementById(
+                            dropdown.querySelector("[id^='selectedAppId-']").id
+                        );
+                        if (hiddenField) {
+                            hiddenField.value = appId;
+                        }
+                        
+                        // Update the display text
+                        const selectedText = dropdown.querySelector(".selected-text");
+                        if (selectedText) {
+                            selectedText.textContent = appName;
+                            selectedText.classList.add("selected");
+                        }
+                        
+                        // Check if this app is already subscribed (disabled)
+                        const subscribeButton = card.querySelector(".common-btn-primary[disabled]");
+                        if (appItem.classList.contains("disabled")) {
+                            // Keep the button disabled if the app is already subscribed
+                            if (subscribeButton && !subscribeButton.disabled) {
+                                subscribeButton.setAttribute("disabled", "disabled");
+                            }
+                        } else {
+                            // Enable the Subscribe button if app is not already subscribed
+                            if (subscribeButton) {
+                                subscribeButton.removeAttribute("disabled");
+                            }
+                        }
+                        return; // Exit early as we've handled the app selection from URL params
+                    }
+                }
+                
+                // Fall back to selecting the first available app if no app from params or app from params not found
                 const firstAvailableApp = dropdown.querySelector(".select-item:not(.disabled)");
                 if (firstAvailableApp) {
                     appId = firstAvailableApp.getAttribute("data-value");
-                    appName = firstAvailableApp.getAttribute("data-app-name");
+                    const appName = firstAvailableApp.getAttribute("data-app-name");
                     // Update hidden input with selected app ID
                     const hiddenField = document.getElementById(
                         dropdown.querySelector("[id^='selectedAppId-']").id
@@ -383,43 +424,11 @@ document.addEventListener("DOMContentLoaded", function () {
                                 // Close the dropdown
                                 selectItems.classList.remove("show");
                                 selectSelected.setAttribute("aria-expanded", "false");
-                                
+
                                 const subscribeButton = card.querySelector(".common-btn-primary");
                                 if (subscribeButton) {
                                     // Find and enable the subscribe button if it's disabled
                                     subscribeButton.removeAttribute("disabled");
-                                    
-                                    // Find the subscribe button and click it automatically
-                                    const subscribeBtn = card.querySelector(".common-btn-primary");
-                                    if (subscribeBtn) {
-                                        // Show loading state before performing subscription
-                                        showSubscribeButtonLoading(subscribeBtn);
-                                        
-                                        // Get the onclick attribute value
-                                        const onclickAttr = subscribeBtn.getAttribute('onclick');
-                                        
-                                        if (onclickAttr) {
-                                            // Execute the onclick function directly
-                                            try {
-                                                // Replace the showSubscribeButtonLoading call in the onclick attribute
-                                                // to avoid showing the loading state twice
-                                                let modifiedOnclick = onclickAttr.replace('showSubscribeButtonLoading(this);', '');
-                                                eval(modifiedOnclick);
-                                                
-                                                // Show success state after subscription completes
-                                                setTimeout(() => {
-                                                    showSubscribeSuccess(subscribeBtn);
-                                                }, 1000); // Simulate subscription completion after 1 second
-                                            } catch (err) {
-                                                console.error('Failed to subscribe', err);
-                                                // Reset button if subscription fails
-                                                resetSubscribeButtonState(subscribeBtn);
-                                            }
-                                        } else {
-                                            // No onclick attribute, try direct click
-                                            subscribeBtn.click();
-                                        }
-                                    }
                                 }
                             })
                             .catch(error => {

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -182,7 +182,6 @@ document.addEventListener("DOMContentLoaded", function () {
             const searchInput = dropdown.querySelector(".select-search-input");
             const selectItemsContainer = dropdown.querySelector(".select-items-container");
             const createAppOption = dropdown.querySelector(".create-app-option");
-            const searchTermElement = dropdown.querySelector(".search-term");
             
             // Select first non-subscribed app by default
             const selectFirstAvailableApp = () => {
@@ -467,23 +466,42 @@ document.addEventListener("DOMContentLoaded", function () {
 
     const subscriptionCard = document.querySelectorAll(".subscription-card");
     subscriptionCard.forEach(card => {
-        const subscriptionBox = card.querySelector(".subscription-container");
         const dropdown = card.querySelector(".custom-dropdown");
-        const subscribeBtn = card.querySelector(".common-btn-primary.subscription-plan-subscribe-btn");
+        const subscribeBtn = card.querySelector(".common-btn-primary");
 
         if (dropdown && subscribeBtn) {
-            subscribeBtn.addEventListener("click", function (e) {
-                e.preventDefault();
-                dropdown.style.display = "block";
-                dropdown.classList.add("show");
-                subscriptionBox.classList.add("subscription-box");
-            });
-
             // Custom select functionality
             const selectSelected = dropdown.querySelector(".select-selected");
             const selectItems = dropdown.querySelector(".select-items");
-            const selectOptions = dropdown.querySelectorAll(".select-item");
-            const actionItem = dropdown.querySelector(".select-action-item");
+            const hiddenInput = dropdown.querySelector("input[type='hidden']");
+            const searchInput = dropdown.querySelector(".select-search-input");
+            const selectItemsContainer = dropdown.querySelector(".select-items-container");
+            const createAppOption = dropdown.querySelector(".create-app-option");
+            const searchTermElement = dropdown.querySelector(".search-term");
+
+            // Select first non-subscribed app by default
+            const selectFirstAvailableApp = () => {
+                // Select the first available app
+                const firstAvailableApp = dropdown.querySelector(".select-item:not(.disabled)");
+                if (firstAvailableApp) {
+                    appId = firstAvailableApp.getAttribute("data-value");
+                    const appName = firstAvailableApp.getAttribute("data-app-name");
+                    // Update hidden input with selected app ID
+                    if (hiddenInput) {
+                        hiddenInput.value = appId;
+                    }
+                    
+                    // Update the display text
+                    const selectedText = selectSelected.querySelector(".selected-text");
+                    if (selectedText) {
+                        selectedText.textContent = appName;
+                        selectedText.classList.add("selected");
+                    }
+                }
+            };
+            
+            // Call this function when the page loads
+            selectFirstAvailableApp();
 
             // Toggle dropdown when clicking on the selected item
             selectSelected.addEventListener("click", function (e) {
@@ -491,19 +509,150 @@ document.addEventListener("DOMContentLoaded", function () {
                 selectItems.classList.toggle("show");
                 selectSelected.setAttribute("aria-expanded",
                     selectItems.classList.contains("show") ? "true" : "false");
+                
+                // Focus on search input when dropdown is opened
+                if (selectItems.classList.contains("show") && searchInput) {
+                    setTimeout(() => searchInput.focus(), 100);
+                }
             });
 
-            // Handle action item click (Create Application)
-            if (actionItem) {
-                actionItem.addEventListener("click", function (e) {
+            // Add search functionality
+            if (searchInput) {
+                searchInput.addEventListener("input", function(e) {
+                    const searchValue = e.target.value.trim();
+                    const searchValueLower = searchValue.toLowerCase();
+                    const appItems = selectItemsContainer.querySelectorAll(".select-item");
+                    const createAppContainer = dropdown.querySelector(".create-app-container");
+                    let exactMatch = false;
+                    
+                    appItems.forEach(item => {
+                        const appName = item.getAttribute("data-app-name").toLowerCase();
+                        if (appName.includes(searchValueLower)) {
+                            item.style.display = "flex";
+                            if (appName === searchValueLower) {
+                                exactMatch = true;
+                            }
+                        } else {
+                            item.style.display = "none";
+                        }
+                    });
+                    
+                    // Update the search term in the create option and show/hide create option
+                    if (searchValue && searchTermElement) {
+                        searchTermElement.textContent = searchValue;
+                        if (exactMatch || !searchValue) {
+                            createAppContainer.style.display = "none";
+                        } else {
+                            createAppContainer.style.display = "block";
+                        }
+                    } else {
+                        createAppContainer.style.display = "none";
+                    }
+                });
+                
+                // Prevent dropdown from closing when clicking in search input
+                searchInput.addEventListener("click", function(e) {
                     e.stopPropagation();
+                });
+            }
 
-                    // Open the create application modal
-                    loadModal('createAppModal');
-
-                    // Close the dropdown
+            // Handle selection of application items
+            const selectableItems = dropdown.querySelectorAll(".select-item:not(.disabled)");
+            selectableItems.forEach(item => {
+                item.addEventListener("click", function(e) {
+                    e.stopPropagation();
+                    
+                    // Get application data
+                    const appId = this.getAttribute("data-value");
+                    const appName = this.getAttribute("data-app-name");
+                    
+                    // Update hidden input with selected app ID
+                    if (hiddenInput) {
+                        hiddenInput.value = appId;
+                    }
+                    
+                    // Update the display text
+                    const selectedText = selectSelected.querySelector(".selected-text");
+                    if (selectedText) {
+                        selectedText.textContent = appName;
+                        selectedText.classList.add("selected");
+                    }
+                    
+                    // Close dropdown
                     selectItems.classList.remove("show");
+                    
+                    // Update aria-expanded attribute
                     selectSelected.setAttribute("aria-expanded", "false");
+                });
+            });
+
+            // Function to create application directly via API
+            async function createApplicationDirectly(name, description = '') {
+                try {
+                    const response = await fetch('/devportal/applications', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                            name,
+                            description,
+                            type: 'WEB',
+                        }),
+                    });
+
+                    if (!response.ok) {
+                        const errorData = await response.json();
+                        throw new Error(errorData.message || `HTTP error! Status: ${response.status}`);
+                    }
+
+                    const responseData = await response.json();
+                    await showAlert(responseData.message || 'Application created successfully!', 'success');
+                    
+                    return responseData; // Return the full response to access applicationId
+                } catch (error) {
+                    console.error('Error creating application:', error);
+                    await showAlert(error.message || 'Failed to create application.', 'error');
+                    throw error;
+                }
+            }
+
+            // Handle create app option click
+            if (createAppOption) {
+                createAppOption.addEventListener("click", function(e) {
+                    e.stopPropagation();
+                    
+                    const appName = searchInput.value.trim();
+                    if (appName) {
+                        // Show loading state
+                        createAppOption.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Creating...';
+                        createAppOption.classList.add('disabled');
+                        
+                        // Call the API to create the application directly
+                        createApplicationDirectly(appName)
+                            .then(response => {
+                                // Update hidden input with the new application ID
+                                if (hiddenInput) {
+                                    hiddenInput.value = response.id;
+                                }
+                                
+                                // Update the display text to show the new application
+                                const selectedText = selectSelected.querySelector(".selected-text");
+                                if (selectedText) {
+                                    selectedText.textContent = appName;
+                                    selectedText.classList.add("selected");
+                                }
+                                
+                                // Close the dropdown
+                                selectItems.classList.remove("show");
+                                selectSelected.setAttribute("aria-expanded", "false");
+                            })
+                            .catch(error => {
+                                // Reset the button on error
+                                createAppOption.innerHTML = `Create application "<span class="search-term">${appName}</span>"`;
+                                createAppOption.classList.remove('disabled');
+                            });
+                    }
                 });
             }
 
@@ -511,6 +660,23 @@ document.addEventListener("DOMContentLoaded", function () {
             document.addEventListener("click", function () {
                 selectItems.classList.remove("show");
                 selectSelected.setAttribute("aria-expanded", "false");
+                
+                // Clear search input when closing dropdown
+                if (searchInput) {
+                    searchInput.value = '';
+                    
+                    // Reset visibility of all items
+                    const appItems = selectItemsContainer?.querySelectorAll(".select-item");
+                    appItems?.forEach(item => {
+                        item.style.display = "flex";
+                    });
+                    
+                    // Hide create app container
+                    const createAppContainer = dropdown.querySelector(".create-app-container");
+                    if (createAppContainer) {
+                        createAppContainer.style.display = "none";
+                    }
+                }
             });
         }
     });

--- a/src/scripts/subscription.js
+++ b/src/scripts/subscription.js
@@ -204,8 +204,8 @@ async function subscribe(orgID, applicationID, apiId, apiReferenceID, policyId, 
                 window.showSubscribeSuccess(subscribeButton);
             }
 
-            await showAlert('Subscribed successfully!', 'success');
             closeModal('planModal-' + apiId);
+            await showAlert('Subscribed successfully!', 'success');
 
             // Redirect after a short delay to show the success state
             setTimeout(() => {

--- a/src/scripts/subscription.js
+++ b/src/scripts/subscription.js
@@ -174,29 +174,17 @@ function loadModal(modalID) {
 async function subscribe(orgID, applicationID, apiId, apiReferenceID, policyId, policyName) {
     console.log('Subscribing to API:', apiId);
     try {
+        const card = document.getElementById('apiCard-' + apiId) ? document.getElementById('apiCard-' + apiId) :
+            document.getElementById('subscriptionCard-' + policyId) ? document.getElementById('subscriptionCard-' + policyId) : null;
+
         // Get the subscribe button (we may have already set loading state)
-        const subscribeButton = document.getElementById('apiCard-' + apiId).querySelector(".common-btn-primary");
-        
+        const subscribeButton = card ? card.querySelector(".common-btn-primary") : null;
+
         if (!applicationID) {
-            const hiddenField = document.getElementById('selectedAppId-' + apiId);
+            // get input hidden
+            const hiddenField = card ? card.querySelector('input[type="hidden"]') : null;
             if (hiddenField && hiddenField.value) {
                 applicationID = hiddenField.value;
-            }
-        }
-
-        if (document.getElementById('apiSelect')) {
-            if (!apiId) {
-                apiId = document.getElementById('apiSelect').value;
-            }
-            if (!apiReferenceID) {
-                apiReferenceID = document.getElementById('apiSelect').selectedOptions[0].getAttribute('data-apiRefID');
-            }
-        }
-
-        if (document.getElementById('planSelect')) {
-            policyId = document.getElementById('planSelect').value;
-            if (!policyName) {
-                policyName = planSelect.selectedOptions[0].getAttribute('data-policyName');
             }
         }
 
@@ -214,23 +202,11 @@ async function subscribe(orgID, applicationID, apiId, apiReferenceID, policyId, 
             // Show success state on the button
             if (subscribeButton && typeof window.showSubscribeSuccess === 'function') {
                 window.showSubscribeSuccess(subscribeButton);
-            } else {
-                const subBtn = document.getElementById('subscribe-btn-' + policyId);
-                if (subBtn) {
-                    subBtn.innerText = 'Subscribed!';
-                    subBtn.disabled = true;
-                    
-                    // Reset after 2 seconds
-                    setTimeout(() => {
-                        subBtn.innerText = 'Subscribe';
-                        subBtn.disabled = false;
-                    }, 2000);
-                }
             }
-            
+
             await showAlert('Subscribed successfully!', 'success');
             closeModal('planModal-' + apiId);
-            
+
             // Redirect after a short delay to show the success state
             setTimeout(() => {
                 const url = new URL(window.location.origin + window.location.pathname);
@@ -238,23 +214,27 @@ async function subscribe(orgID, applicationID, apiId, apiReferenceID, policyId, 
             }, 2000);
         } else {
             console.error('Failed to create subscription:', responseData);
-            
+
             // Reset button state if subscription fails
             if (subscribeButton && typeof window.resetSubscribeButtonState === 'function') {
                 window.resetSubscribeButtonState(subscribeButton);
             }
-            
+
             await showAlert(`Failed to create subscription. Please try again.\n${responseData.description}`, 'error');
         }
     } catch (error) {
         console.error('Error:', error);
-        
+
         // Reset button state on error
-        const subscribeButton = document.getElementById('apiCard-' + apiId).querySelector(".common-btn-primary");
+        const card = document.getElementById('apiCard-' + apiId) ? document.getElementById('apiCard-' + apiId) :
+            document.getElementById('subscriptionCard-' + policyId) ? document.getElementById('subscriptionCard-' + policyId) : null;
+
+        // Get the subscribe button (we may have already set loading state)
+        const subscribeButton = card ? card.querySelector(".common-btn-primary") : null;
         if (subscribeButton && typeof window.resetSubscribeButtonState === 'function') {
             window.resetSubscribeButtonState(subscribeButton);
         }
-        
+
         await showAlert(`An error occurred while subscribing: \n${error.message}`, 'error');
     }
 }


### PR DESCRIPTION
## Purpose
Implement the new API subscription flow on the API page

## Goals
Fix subscribe button alignment issues
Remove the subscription outline box
Duplicate API subscription logic to API specific page
Minor fixes for hero section responsiveness

## Approach
Updated the subscription flow and the subscription logic on the api-subscription-plans component

## Samples
### Using param to pass the selected app:
https://github.com/user-attachments/assets/d0db4f20-740c-4a2e-860f-7a329b6ccc8c

### When there are multiple plans:
https://github.com/user-attachments/assets/03785137-52cd-4600-bd18-341794763c2e

### Subscribing through the API page:

https://github.com/user-attachments/assets/571ccf75-ffe3-4045-9b6e-132696c36ead
