### PR TITLE
Display create an app in dropdown when no apps available

### DIFF
--- a/src/defaultContent/pages/api-landing/partials/api-subscription-plans.hbs
+++ b/src/defaultContent/pages/api-landing/partials/api-subscription-plans.hbs
@@ -36,7 +36,7 @@
                                 <input type="hidden" id="selectedAppId-{{policyID}}" value="" />
                                 <div class="custom-select-container">
                                     <div class="select-selected" aria-expanded="false">
-                                        <span class="selected-text">Select an app</span>
+                                        <span class="selected-text">Create an app</span>
                                         <span class="select-arrow"></span>
                                     </div>
                                     <div class="select-items" role="listbox">

--- a/src/defaultContent/pages/apis/partials/api-listing.hbs
+++ b/src/defaultContent/pages/apis/partials/api-listing.hbs
@@ -93,7 +93,7 @@
                   <input type="hidden" id="selectedAppId-{{apiID}}" value="" />
                   <div class="custom-select-container">
                     <div class="select-selected" role="combobox" aria-expanded="false" aria-haspopup="listbox">
-                      <span class="selected-text small">Select an app</span>
+                      <span class="selected-text small">Create an app</span>
                       <span class="select-arrow"></span>
                     </div>
                     <div class="select-items" role="listbox">


### PR DESCRIPTION
## Purpose
$subject

## Goals
Display the create option when no apps available or all apps are subscribed

## Approach
Replaced the default text, as there are no other scenarios where we show the select option

## Samples
N/A
