### PR TITLE
Remove auto hiding timeout from error overlays

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -924,10 +924,13 @@ document.addEventListener("DOMContentLoaded", function () {
             // Show the overlay (remove hidden class if it exists)
             overlay.classList.remove('hidden');
             
-            // Auto-hide after the designated time
-            overlay.hideTimer = setTimeout(() => {
-                overlay.classList.add('hidden');
-            }, 5000);
+            // Auto-hide after the designated time only for success messages
+            // Error messages remain visible until user closes them manually
+            if (type === 'success') {
+                overlay.hideTimer = setTimeout(() => {
+                    overlay.classList.add('hidden');
+                }, 5000);
+            }
             
             return overlay;
         }

--- a/src/scripts/subscription.js
+++ b/src/scripts/subscription.js
@@ -201,10 +201,10 @@ async function subscribe(orgID, applicationID, apiId, apiReferenceID, policyId, 
         // Always reset button state and close modal
         const planButton = document.getElementById('subscribe-btn-' + policyId);
         if (planButton) {
-            resetButtonState(planButton);
+            resetSubscribeButtonState(planButton);
         }
         closeModal('planModal-' + apiId);
-        resetButtonState(subscribeButton);
+        resetSubscribeButtonState(subscribeButton);
 
         if (response.ok) {
             // Show success notification
@@ -222,10 +222,10 @@ async function subscribe(orgID, applicationID, apiId, apiReferenceID, policyId, 
         // Always reset button state and close modal
         const planButton = document.getElementById('subscribe-btn-' + policyId);
         if (planButton) {
-            resetButtonState(planButton);
+            resetSubscribeButtonState(planButton);
         }
         closeModal('planModal-' + apiId);
-        resetButtonState(subscribeButton);
+        resetSubscribeButtonState(subscribeButton);
         
         const errorMessage = `Error while subscribing: ${error.message}`;
         showSubscriptionMessage(messageOverlay, errorMessage, 'error');
@@ -239,7 +239,7 @@ function getSubscriptionCard(apiId, policyId) {
            null;
 }
 
-function resetButtonState(button) {
+function resetSubscribeButtonState(button) {
     if (button && typeof window.resetSubscribeButtonState === 'function') {
         window.resetSubscribeButtonState(button);
     }


### PR DESCRIPTION
## Purpose
Prevent error messages from automatically hiding

## Goals
Giving the user more time to read the error messages

## Approach
Add the timeout only to the success alerts

## Samples
N/A