### PR TITLE
Improve the alerts and oauth2 key modification error handling

### DIFF
--- a/src/pages/application/partials/keys-modify.hbs
+++ b/src/pages/application/partials/keys-modify.hbs
@@ -7,6 +7,7 @@
                     onclick="closeModal('keysModifyModal')"></button>
             </div>
             <div class="custom-modal-body">
+                <div id="keyUpdateErrorContainer" class="alert alert-danger small" style="display: none;"></div>
         
                 <div class="container">
                     {{#each keyManagersMetadata}}

--- a/src/pages/application/partials/overview.hbs
+++ b/src/pages/application/partials/overview.hbs
@@ -104,7 +104,7 @@
         </div>
 
         <!-- Error message container for key generation and token generation -->
-        <div id="keyGenerationErrorContainer" class="mt-2 text-danger" style="display: none; font-size: 0.75rem;"></div>
+        <div id="keyGenerationErrorContainer" class="mt-2 text-danger" style="display: none; font-size: 0.75rem; word-wrap: break-word;"></div>
 
         {{/let}}
         {{/if}}

--- a/src/pages/partials/alert.hbs
+++ b/src/pages/partials/alert.hbs
@@ -13,7 +13,8 @@
     >
       <div class="modal-dialog">
         <div class="modal-content">
-          <div class="modal-body {{typeClass}}">
+          <div class="modal-body">
+            <i class="alert-icon bi"></i>
             <p class="modal-message">{{message}}</p>
           </div>
         </div>

--- a/src/scripts/alert.js
+++ b/src/scripts/alert.js
@@ -3,11 +3,20 @@ function showAlert(message, type) {
         const modalElement = document.getElementById('alertModal');
         const modalMessage = modalElement.querySelector('.modal-message');
         const modalBody = modalElement.querySelector('.modal-body');
+        const alertIcon = modalElement.querySelector('.alert-icon');
 
         modalMessage.textContent = message;
 
         modalBody.classList.remove('success', 'error');
         modalBody.classList.add(type);
+        
+        // Set appropriate icon based on alert type
+        alertIcon.className = 'alert-icon bi';
+        if (type === 'success') {
+            alertIcon.classList.add('bi-check-circle-fill');
+        } else if (type === 'error') {
+            alertIcon.classList.add('bi-exclamation-circle-fill');
+        }
 
         const bootstrapModal = new bootstrap.Modal(modalElement, { backdrop: false });
         bootstrapModal.show();
@@ -19,6 +28,6 @@ function showAlert(message, type) {
                 modalElement.classList.remove('fade-out');
                 resolve(); 
             }, 500); 
-        }, 2300); 
+        }, 2300);
     });
 }

--- a/src/scripts/oauth2-key-generation.js
+++ b/src/scripts/oauth2-key-generation.js
@@ -279,6 +279,17 @@ function getFormData(formData, keyManager, clientName, appID) {
 
 
 async function updateApplicationKey(formId, appMap, keyType, keyManager, keyManagerId, clientName) {
+    // Get the update button and set loading state
+    const updateBtn = document.getElementById('applicationKeyUpdateButton');
+    const originalContent = updateBtn.innerHTML;
+    updateBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Updating...';
+    updateBtn.disabled = true;
+    
+    // Clear any previous error messages
+    const errorContainer = document.getElementById('keyUpdateErrorContainer');
+    errorContainer.style.display = 'none';
+    errorContainer.textContent = '';
+
     const form = document.getElementById(formId);
     const formData = new FormData(form);
     const jsonAppdata = appMap ? JSON.parse(appMap) : null;
@@ -306,19 +317,44 @@ async function updateApplicationKey(formId, appMap, keyType, keyManager, keyMana
             body: payload,
         });
 
-
         const responseData = await response.json();
         if (response.ok) {
             await showAlert('Application keys generated successfully!', 'success');
             const url = new URL(window.location.origin + window.location.pathname);
             window.location.href = url.toString();
         } else {
-            console.error('Failed to generate keys:', responseData);
-            await showAlert(`Failed to generate application keys. Please try again.\n${responseData.description}`, 'error');
+            console.error('Failed to update keys:', responseData);
+            
+            // Enhanced error message with better formatting
+            let errorMessage = 'Failed to update application credentials';
+            if (responseData.description) {
+                errorMessage += `: ${responseData.description}`;
+            } else if (responseData.message) {
+                errorMessage += `: ${responseData.message}`;
+            }
+            
+            errorContainer.textContent = errorMessage;
+            errorContainer.style.display = 'block';
+            
+            // Restore button state
+            updateBtn.innerHTML = originalContent;
+            updateBtn.disabled = false;
         }
     } catch (error) {
         console.error('Error:', error);
-        await showAlert(`An error occurred generating application keys: \n${error.message}`, 'error');
+        
+        // Display error message in the modal
+        let errorMessage = 'Failed to update application credentials';
+        if (error.message) {
+            errorMessage += `: ${error.message}`;
+        }
+        
+        errorContainer.textContent = errorMessage;
+        errorContainer.style.display = 'block';
+        
+        // Restore button state
+        updateBtn.innerHTML = originalContent;
+        updateBtn.disabled = false;
     }
 }
 

--- a/src/styles/alert.css
+++ b/src/styles/alert.css
@@ -3,33 +3,47 @@
     bottom: 20px;
     right: 20px;
     width: auto;
-    max-width: 500px; 
+    min-width: 300px;
+    max-width: 500px;
     animation: fadeIn 0.5s;
     z-index: 1055;
 }
 
 .custom-alert .modal-content {
-    border-radius: 12px; 
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); 
-    overflow: hidden; 
-    padding: 0; 
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+    padding: 0;
+    border: 0;
 }
 
 .custom-alert .modal-body {
-    font-size: 14px; 
+    font-size: 14px;
     height: 100%;
     display: flex;
     align-items: center;
+    padding: 12px 15px;
+    gap: 10px;
 }
 
 .custom-alert .modal-body.success {
-    background-color: #95d5b2; 
-    color: #ffffff;    
+    background-color: #95d5b2;
+    color: #0a3622;
 }
 
 .custom-alert .modal-body.error {
-    background-color: #ff8585; 
-    color: #ffffff;
+    background-color: #ff8585;
+    color: #4f0000;
+}
+
+.custom-alert .alert-icon {
+    font-size: 0.875rem;
+    width: auto;
+    height: auto;
+}
+
+.custom-alert .modal-message {
+    margin: 0;
+    font-weight: 500;
 }
 
 @keyframes fadeIn {
@@ -37,8 +51,24 @@
         opacity: 0;
         transform: translateY(20px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);
     }
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+}
+
+.fade-out {
+    animation: fadeOut 0.5s;
 }


### PR DESCRIPTION
## Purpose
Improving the alert modals

## Goals
Improving UI/UX

## Approach
Updated the success/error alerts
Added loading state to update button of keys-modify modal
Display the oauth modification errors within the modal itself instead of showing an alert

## Samples

#### Sample error alert:

<img width="75%" alt="Screenshot 2025-04-04 at 11 38 32" src="https://github.com/user-attachments/assets/09b76907-4a6c-492c-a61e-ec7f438b7c41" />

#### Sample success alert:
<img width="75%" alt="Screenshot 2025-04-04 at 11 38 25" src="https://github.com/user-attachments/assets/bb6ab23e-34bf-4d70-994f-6a9a39f761f4" />

#### Oauth2 modal errors:

https://github.com/user-attachments/assets/d71c2ea0-47ac-4f7c-8a5c-cedc8998406b


