### PR TITLE
Add html form validations to the key modification form

### DIFF
--- a/src/defaultContent/pages/docs/page.hbs
+++ b/src/defaultContent/pages/docs/page.hbs
@@ -28,9 +28,7 @@
                     </div>
                     <div class="doc-links">
                         <a href="{{../baseUrl}}/docs/specification" class="doc-link">
-                            <div class="doc-icon">
-                                <img class="align-top" src="https://raw.githubusercontent.com/wso2/docs-bijira/refs/heads/main/en/devportal-theming/api-definition.svg" alt="doc" />
-                            </div>
+                            <i class="bi bi-code"></i>
                             <div class="doc-title">
                                 API Definition
                             </div>
@@ -45,9 +43,7 @@
                     <div class="doc-links">
                         {{#names}}
                         <a href="{{../../baseUrl}}/docs/{{../type}}/{{this}}" class="doc-link">
-                            <div class="doc-icon">
-                                <img class="align-top" src="https://raw.githubusercontent.com/wso2/docs-bijira/refs/heads/main/en/devportal-theming/docs-icon.svg" alt="doc" />
-                            </div>
+                            <i class="bi bi-file-text"></i>
                             <div class="doc-title">
                                 {{beforeSeparator this "."}}
                             </div>
@@ -58,7 +54,11 @@
                 {{/if}}
                 {{/docTypes}}
             </aside>
-            {{> api-doc}}
+            <div class="doc-content-wrapper">
+                <section class="doc-section">
+                    {{> api-doc}}
+                </section>
+            </div>
         </div>
     </div>
 </main>

--- a/src/defaultContent/pages/docs/partials/api-doc.hbs
+++ b/src/defaultContent/pages/docs/partials/api-doc.hbs
@@ -16,10 +16,8 @@
  * under the License.
  */
  -->
-<section class="doc-section">
-    {{#if isAPIDefinition}}
-    {{> api-specification}}
-    {{else}}
-    {{{apiMD}}}
-    {{/if}}
-</section>
+{{#if isAPIDefinition}}
+{{> api-specification}}
+{{else}}
+{{{apiMD}}}
+{{/if}}

--- a/src/defaultContent/styles/doc.css
+++ b/src/defaultContent/styles/doc.css
@@ -53,11 +53,19 @@
     opacity: 0.5;
 }
 
-.doc-section {
-    padding: 1rem;
+.doc-content-wrapper {
+    width: 100%;
+    overflow-x: auto;
     border: 0.5px solid #e0e2e9;
     border-radius: 16px;
     box-shadow: 0px 2px 4px #0000000a;
+    display: flex;
+}
+
+.doc-section {
+    flex: 1;
+    padding: 2rem;
+    max-height: 100%;
 }
 
 .doc-section-title {
@@ -94,15 +102,10 @@
     background-color: var(--secondary-bg-color);
 }
 
-.doc-icon {
-    width: 16px;
-    height: 16px;
-    flex-shrink: 0;
-}
-
-.doc-icon img {
-    width: 100%;
-    height: 100%;
+.doc-link i {
+    width: auto;
+    height: auto;
+    color: var(--primary-main-color);
 }
 
 .doc-title {
@@ -130,5 +133,7 @@
 
     .documents-sidebar {
         width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #e0e2e9;
     }
 }

--- a/src/pages/application/partials/keys-modify.hbs
+++ b/src/pages/application/partials/keys-modify.hbs
@@ -17,7 +17,10 @@
                     {{!-- Advanced configurations section --}}
                     <div class="container KMConfig mt-4" id="KMData_{{../name}}">
                         <form
-                            id='applicationKeyGenerateForm-{{../id}}-{{#if ../../isProduction}}production{{else}}sandbox{{/if}}'>
+                            id='applicationKeyGenerateForm-{{../id}}-{{#if ../../isProduction}}production{{else}}sandbox{{/if}}'
+                            onsubmit="event.preventDefault(); updateApplicationKey(this.id,
+                                '{{json ../../applicationMetadata.appMap}}', {{#if ../../isProduction}}'PRODUCTION'{{else}}'SANDBOX'{{/if}}, '{{../name}}',
+                                '{{keys.keyMappingId}}', '{{keys.clientName}}');">
                             <div>
                                 <div class="row mb-2">
                                     <div class="col-md-4">
@@ -59,7 +62,7 @@
                                     </div>
                                     <div class="col-md-8">
                                         <div class="keygen-input-container">
-                                            <input type="text" name="callbackURL" placeholder="Callback URLs"
+                                            <input type="url" name="callbackURL" placeholder="Callback URLs"
                                                 value="{{keys.callbackUrl}}" class="form-control" />
                                         </div>
                                     </div>
@@ -146,9 +149,7 @@
                                 Cancel
                             </button>
                             <button class="common-btn-primary" id="applicationKeyUpdateButton" name="http-values"
-                                type="button" onClick="updateApplicationKey('applicationKeyGenerateForm-{{../id}}-{{#if ../../isProduction}}production{{else}}sandbox{{/if}}',
-                                '{{json ../../applicationMetadata.appMap}}', {{#if ../../isProduction}}'PRODUCTION'{{else}}'SANDBOX'{{/if}}, '{{../name}}',
-                                '{{keys.keyMappingId}}', '{{keys.clientName}}')">
+                                type="submit" form="applicationKeyGenerateForm-{{../id}}-{{#if ../../isProduction}}production{{else}}sandbox{{/if}}">
                                 Update
                             </button>
                         </div>

--- a/src/scripts/oauth2-key-generation.js
+++ b/src/scripts/oauth2-key-generation.js
@@ -601,12 +601,15 @@ function loadKeysModifyModal() {
         const callbackUrlRow = modal.querySelector('#callback-url-row');
         // Find PKCE-related configuration fields
         const pkceFields = modal.querySelectorAll('#row-pkceMandatory, #row-pkceSupportPlain');
-        console.log(pkceFields);
         
         // Handle callback URL visibility
         if (callbackUrlRow) {
             // Set initial visibility based on checkbox state
             callbackUrlRow.style.display = authorizationCodeCheckbox.checked ? 'flex' : 'none';
+            const callbackUrlInput = callbackUrlRow.querySelector('input');
+            if (callbackUrlInput) {
+                callbackUrlInput.required = authorizationCodeCheckbox.checked;
+            }
         }
         
         // Handle PKCE fields visibility
@@ -619,6 +622,10 @@ function loadKeysModifyModal() {
             // Toggle callback URL row
             if (callbackUrlRow) {
                 callbackUrlRow.style.display = this.checked ? 'flex' : 'none';
+                const callbackUrlInput = callbackUrlRow.querySelector('input');
+                if (callbackUrlInput) {
+                    callbackUrlInput.required = this.checked;
+                }
             }
             
             // Toggle PKCE fields


### PR DESCRIPTION
## Purpose
Add form validations to the oauth2 key modification modal

## Goals
Adding form validations

## Approach
Removed the button onclick and added the onsubmit function to the form, so the default html form validations will run.

## Samples
https://github.com/user-attachments/assets/57402f00-9516-4ae7-ad30-6991b7078b22


