### PR TITLE
Add backend support for adding MCP API support

### DIFF
--- a/src/controllers/apiContentController.js
+++ b/src/controllers/apiContentController.js
@@ -191,6 +191,7 @@ const loadAPIContent = async (req, res) => {
             //check whether api content exists
             let loadDefault = false
             let apiDetails = "";
+            let schemaDefinition = "";
             let apiDefinition = {};
             const markdownResponse = await apiDao.getAPIFile(constants.FILE_NAME.API_MD_CONTENT_FILE_NAME, constants.DOC_TYPES.API_LANDING, orgID, apiID);
             if (!markdownResponse) {
@@ -206,6 +207,21 @@ const loadAPIContent = async (req, res) => {
                             apiDetails["serverDetails"] = "";
                         } else {
                             apiDetails["serverDetails"] = metaData.endPoints;
+                        }
+                    }
+                    if (constants.API_TYPE.MCP === metaData.apiInfo?.apiType) {
+                        try {
+                            let rawSchema = await apiDao.getAPIFile(
+                                constants.FILE_NAME.SCHEMA_DEFINITION_FILE_NAME,
+                                constants.DOC_TYPES.SCHEMA_DEFINITION,
+                                orgID,
+                                apiID
+                            );
+                            const schemaString = rawSchema.toString(constants.CHARSET_UTF8);
+                            schemaDefinition = JSON.parse(schemaString);
+                        } catch (err) {
+                            console.error("Failed to load or parse schema definition:", err);
+                            throw err;
                         }
                     }
                 }
@@ -236,7 +252,8 @@ const loadAPIContent = async (req, res) => {
                 schemaUrl: `${req.protocol}://${req.get('host')}${constants.ROUTE.DEVPORTAL_ASSETS_BASE_PATH}${orgID}/${constants.ROUTE.API_FILE_PATH}${apiID}${constants.API_TEMPLATE_FILE_NAME}${constants.FILE_NAME.API_DEFINITION_XML}`,
                 loadDefault: loadDefault,
                 resources: apiDetails,
-                orgID: orgID
+                orgID: orgID,
+                schemaDefinition: schemaDefinition,
             };
             html = await renderTemplateFromAPI(templateContent, orgID, orgName, "pages/api-landing", viewName);
         } catch (error) {

--- a/src/controllers/applicationsContentController.js
+++ b/src/controllers/applicationsContentController.js
@@ -146,6 +146,7 @@ const loadApplication = async (req, res) => {
                     apiDTO.name = api.apiInfo.apiName;
                     apiDTO.apiID = api.apiID;
                     apiDTO.version = api.apiInfo.apiVersion;
+                    apiDTO.apiType = api.apiInfo.apiType;
                     apiDTO.apiInfo.apiImageMetadata = api.apiInfo.apiImageMetadata;
                     apiDTO.image = api.apiInfo.apiImageMetadata["api-icon"];
                     apiDTO.subID = sub.dataValues.DP_APPLICATIONs[0].dataValues.DP_API_SUBSCRIPTION.dataValues.SUB_ID;

--- a/src/dao/apiMetadata.js
+++ b/src/dao/apiMetadata.js
@@ -552,11 +552,11 @@ const storeAPIImageMetadata = async (apiImages, apiID, t) => {
     }
 }
 
-const storeAPIFile = async (apiDefinition, fileName, apiID, type, t) => {
+const storeAPIFile = async (apiFile, fileName, apiID, type, t) => {
 
     try {
         const apiFileResponse = await APIContent.create({
-            API_FILE: apiDefinition,
+            API_FILE: apiFile,
             FILE_NAME: fileName,
             API_ID: apiID,
             TYPE: type
@@ -1343,17 +1343,17 @@ const deleteImage = async (imageTag, apiID, t) => {
     }
 }
 
-const updateAPIFile = async (apiFile, fileName, apiID, orgID, t) => {
+const updateAPIFile = async (apiFile, fileName, apiID, orgID, type, t) => {
 
     try {
-        const apiFileResponse = await getAPIFile(fileName, constants.DOC_TYPES.API_DEFINITION, orgID, apiID, t);
+        const apiFileResponse = await getAPIFile(fileName, type, orgID, apiID, t);
         let fileUpdateResponse;
         if (apiFileResponse == null || apiFileResponse == undefined) {
             fileUpdateResponse = await APIContent.create({
                 API_FILE: apiFile,
                 FILE_NAME: fileName,
                 API_ID: apiID,
-                TYPE: constants.DOC_TYPES.API_DEFINITION
+                TYPE: type
             }, { transaction: t });
         } else {
             fileUpdateResponse = await APIContent.update({
@@ -1364,7 +1364,7 @@ const updateAPIFile = async (apiFile, fileName, apiID, orgID, t) => {
                     where: {
                         API_ID: apiID,
                         FILE_NAME: fileName,
-                        TYPE: constants.DOC_TYPES.API_DEFINITION
+                        TYPE: type
                     },
                     include: [
                         {

--- a/src/routes/devportalRoute.js
+++ b/src/routes/devportalRoute.js
@@ -23,7 +23,7 @@ const adminService = require('../services/adminService');
 const devportalController = require('../controllers/devportalController');
 const multer = require('multer');
 const storage = multer.memoryStorage()
-const apiDefinition = multer({ storage: storage })
+const multipartHandler = multer({storage: storage})
 const { ensureAuthenticated, validateAuthentication, enforceSecuirty } = require('../middlewares/ensureAuthenticated');
 const constants = require('../utils/constants');
 
@@ -50,10 +50,24 @@ router.put('/organizations/:orgId/provider', enforceSecuirty(constants.SCOPES.AD
 router.get('/organizations/:orgId/provider', enforceSecuirty(constants.SCOPES.ADMIN), adminService.getProviders);
 router.delete('/organizations/:orgId/provider', enforceSecuirty(constants.SCOPES.ADMIN), adminService.deleteProvider);
 
-router.post('/organizations/:orgId/apis', enforceSecuirty(constants.SCOPES.DEVELOPER), apiDefinition.single('apiDefinition'), apiMetadataService.createAPIMetadata);
+router.post(
+    '/organizations/:orgId/apis',
+    enforceSecuirty(constants.SCOPES.DEVELOPER),
+    multipartHandler.fields([
+        {name: 'apiDefinition', maxCount: 1},
+        {name: 'schemaDefinition', maxCount: 1},
+    ]),
+    apiMetadataService.createAPIMetadata);
 router.get('/organizations/:orgId/apis/:apiId', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.getAPIMetadata);
 router.get('/organizations/:orgId/apis', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.getAllAPIMetadata);
-router.put('/organizations/:orgId/apis/:apiId', enforceSecuirty(constants.SCOPES.DEVELOPER), apiDefinition.single('apiDefinition'), apiMetadataService.updateAPIMetadata);
+router.put(
+    '/organizations/:orgId/apis/:apiId',
+    enforceSecuirty(constants.SCOPES.DEVELOPER),
+    multipartHandler.fields([
+        {name: 'apiDefinition', maxCount: 1},
+        {name: 'schemaDefinition', maxCount: 1},
+    ]),
+    apiMetadataService.updateAPIMetadata);
 router.delete('/organizations/:orgId/apis/:apiId', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.deleteAPIMetadata);
 
 router.post('/organizations/:orgId/subscription-policies', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.addSubscriptionPolicies);
@@ -68,9 +82,23 @@ router.get('/organizations/:orgId/apis/:apiId/template', apiMetadataService.getA
 router.delete('/organizations/:orgId/apis/:apiId/template', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.deleteAPIFile);
 
 // S2S Applied APIS
-router.post('/apis', enforceSecuirty(constants.SCOPES.DEVELOPER), apiDefinition.single('apiDefinition'), apiMetadataService.createAPIMetadata); // s2s applied
+router.post(
+    '/apis',
+    enforceSecuirty(constants.SCOPES.DEVELOPER),
+    multipartHandler.fields([
+        {name: 'apiDefinition', maxCount: 1},
+        {name: 'schemaDefinition', maxCount: 1},
+    ]),
+    apiMetadataService.createAPIMetadata); // s2s applied
 router.get('/apis', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.getAllAPIMetadata); // s2s applied
-router.put('/apis/:apiId', enforceSecuirty(constants.SCOPES.DEVELOPER), apiDefinition.single('apiDefinition'), apiMetadataService.updateAPIMetadata); // s2s applied
+router.put(
+    '/apis/:apiId',
+    enforceSecuirty(constants.SCOPES.DEVELOPER),
+    multipartHandler.fields([
+        {name: 'apiDefinition', maxCount: 1},
+        {name: 'schemaDefinition', maxCount: 1},
+    ]),
+    apiMetadataService.updateAPIMetadata); // s2s applied
 router.delete('/apis/:apiId', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.deleteAPIMetadata); // s2s applied
 
 router.post('/organizations/:orgId/labels', enforceSecuirty(constants.SCOPES.ADMIN), apiMetadataService.createLabels);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -43,11 +43,15 @@ module.exports = {
         PUBLISHED: "PUBLISHED",
         UNPUBLISHED: "CREATED"
     },
+    API_TYPE: {
+        MCP: "MCP"
+    },
     DOC_TYPES: {
         DOC_ID: 'DOC_',
         DOCLINK_ID: 'LINK_',
         API_LANDING: 'MARKETING',
         API_DEFINITION: 'API_DEFINITION',
+        SCHEMA_DEFINITION: 'SCHEMA_DEFINITION',
         IMAGES: 'IMAGE',
         DOCUMENT: 'DOCUMENT',
         LINK: "DOC_LINK",

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -155,6 +155,7 @@ module.exports = {
         API_CONTENT_PARTIAL_NAME: "api-content",
         API_DOC_PARTIAL_NAME: "api-doc",
         API_DEFINITION_FILE_NAME: 'apiDefinition.json',
+        SCHEMA_DEFINITION_FILE_NAME: 'schemaDefinition.json',
         API_SPECIFICATION_PATH: 'specification',
         API_DEFINITION_GRAPHQL: 'apiDefinition.graphql',
         API_DEFINITION_XML: 'apiDefinition.xml',


### PR DESCRIPTION
This PR introduces backend changes to support MCP APIs in the Developer Portal.

Key changes include:

- REST API updates to add or update schemaDefinition (used by MCP tools) for MCP APIs via the console.
- Persistence of schemaDefinition data in the database.
- Enhancements to retrieve schemaDefinition for display in the DevPortal UI.