### PR TITLE
Fix 2.0 swagger endpoint issue

### DIFF
--- a/src/controllers/apiContentController.js
+++ b/src/controllers/apiContentController.js
@@ -511,6 +511,12 @@ async function parseSwagger(api) {
 
 function replaceEndpointParams(apiDefinition, prodEndpoint, sandboxEndpoint) {
 
+    if (apiDefinition.swagger.startsWith('2.')) {
+        if (prodEndpoint.trim().length !== 0) {
+            apiDefinition.host = prodEndpoint.replace(/https?:\/\//, '');
+            apiDefinition.schemes = [prodEndpoint.startsWith('https') ? 'https' : 'http'];
+        }
+    }
     let servers = [];
     if (prodEndpoint.trim().length !== 0) {
         servers.push({


### PR DESCRIPTION
## Purpose
> When an OpenAPI swagger of version 2.0 is published the endpoint is constructed through schema, host and basepath. The fix for this check is done in the PR

## Issues
> https://github.com/wso2-enterprise/apim-saas/issues/708