### PR TITLE
Update tryout page subject to "MCP Playground" for MCP API type and improve token placeholder

### DIFF
--- a/src/controllers/apiContentController.js
+++ b/src/controllers/apiContentController.js
@@ -327,7 +327,8 @@ const loadDocsPage = async (req, res) => {
         const templateContent = {
             apiMD: await loadMarkdown("api-doc.md", filePrefix + '../mock/' + apiHandle + "/" + docType),
             baseUrl: constants.BASE_URL + config.port + "/views/" + viewName + "/api/" + apiHandle,
-            docTypes: docNames
+            docTypes: docNames,
+            apiType: apiMetadata.apiInfo?.apiType
         }
         html = renderTemplate(filePrefix + 'pages/docs/page.hbs', filePrefix + 'layout/main.hbs', templateContent, false);
     } else {
@@ -336,9 +337,12 @@ const loadDocsPage = async (req, res) => {
             const apiID = await apiDao.getAPIId(orgID, apiHandle);
             const viewName = req.params.viewName;
             const docNames = await apiMetadataService.getAPIDocTypes(orgID, apiID)
+            const apiMetadata = await apiDao.getAPIMetadata(orgID, apiID);
+            let apiType = apiMetadata[0].dataValues.API_TYPE;
             const templateContent = {
                 baseUrl: '/' + orgName + '/views/' + viewName + "/api/" + apiHandle,
-                docTypes: docNames
+                docTypes: docNames,
+                apiType: apiType
             };
             html = await renderTemplateFromAPI(templateContent, orgID, orgName, "pages/docs", viewName);
         } catch (error) {
@@ -412,6 +416,7 @@ const loadDocument = async (req, res) => {
             templateContent.baseUrl = constants.BASE_URL + config.port + "/views/" + viewName + "/api/" + apiHandle;
             templateContent.docTypes = docNames;
             templateContent.apiMD = apiMD;
+            templateContent.apiType = apiMetadata.apiInfo?.apiType;
             html = renderTemplate(filePrefix + 'pages/docs/page.hbs', filePrefix + 'layout/main.hbs', templateContent, false);
         } else {
             try {
@@ -427,6 +432,7 @@ const loadDocument = async (req, res) => {
                     templateContent.baseUrl = '/' + orgName + '/views/' + viewName + "/api/" + apiHandle;
                 }
                 templateContent.docTypes = docNames;
+                templateContent.apiType = apiType;
                 html = await renderTemplateFromAPI(templateContent, orgID, orgName, "pages/docs", viewName);
             } catch (error) {
                 console.error(`Failed to load api content :`, error);

--- a/src/defaultContent/pages/docs/page.hbs
+++ b/src/defaultContent/pages/docs/page.hbs
@@ -30,7 +30,11 @@
                         <a href="{{../baseUrl}}/docs/specification" class="doc-link">
                             <i class="bi bi-code"></i>
                             <div class="doc-title">
-                                API Definition
+                                {{#if (eq ../apiType "MCP")}}
+                                    MCP Playground
+                                {{else}}
+                                    API Definition
+                                {{/if}}
                             </div>
                         </a>
                     </div>

--- a/src/pages/partials/api-specification.hbs
+++ b/src/pages/partials/api-specification.hbs
@@ -89,7 +89,7 @@
     </script>
     <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/thisaltennakoon/mcp-inspector@main8/dist/mcp-inspector.umd.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/thisaltennakoon/mcp-inspector@main11/dist/mcp-inspector.umd.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <main>
@@ -119,6 +119,7 @@
             // Then render the actual component
             ReactDOM.render(React.createElement(MCPInspector.default, {
                 url: serverUrl,
+                tokenPlaceholder: 'Bearer <your-token-here>',
             }), rootElement);
         });
     </script>


### PR DESCRIPTION
## Changes

- **Subject Update**: Changed the tryout page subject from "API Definition" to "MCP Playground" when the API type is MCP to better reflect the functionality
- **Token Placeholder Enhancement**: Updated the token input placeholder to clarify that "Bearer" should be prefixed to the token value