### PR TITLE
Add SSE connection closing logic

### DIFF
--- a/src/services/sdkJobService.js
+++ b/src/services/sdkJobService.js
@@ -762,6 +762,8 @@ class SDKJobService extends EventEmitter {
                 console.warn('OpenAPI Generator warnings:', stderr);
             }
 
+            console.log('SDK generation completed successfully. Output directory:', outputDir);
+
             // Clean up spec directory
             try {
                 await fs.promises.rm(specDir, { recursive: true, force: true });
@@ -1057,7 +1059,8 @@ class SDKJobService extends EventEmitter {
                 'src/main/java/org/openapitools/client',
                 'src/main/java/io/swagger/client',
                 'src/main/java/com/example/client',
-                'src/main/java'
+                'src/main/java',
+                'src'
             ];
             
             for (const possiblePath of possiblePaths) {
@@ -1075,7 +1078,7 @@ class SDKJobService extends EventEmitter {
                     console.log(`Directory contents check - api: ${hasApiDir}, model: ${hasModelDir}`);
 
                     if (hasApiDir && hasModelDir) {
-                        console.log(`Found Java package directory: ${fullPath}`);
+                        console.log(`Found package directory: ${fullPath}`);
                         return fullPath;
                     }
                 } else {
@@ -1090,15 +1093,15 @@ class SDKJobService extends EventEmitter {
 
             const foundPath = await this.findJavaPackageRecursively(sdkDir);
             if (foundPath) {
-                console.log(`Found Java package directory recursively: ${foundPath}`);
+                console.log(`Found package directory recursively: ${foundPath}`);
                 return foundPath;
             }
-            
-            console.warn('Could not find Java package directory structure');
+
+            console.warn('Could not find package directory structure');
             return null;
             
         } catch (error) {
-            console.error('Error finding Java package directory:', error);
+            console.error('Error finding package directory:', error);
             return null;
         }
     };
@@ -1471,8 +1474,24 @@ class SDKJobService extends EventEmitter {
 
             const onProgress = (progressData) => {
                 if (progressData.jobId === jobId) {
+                    console.log(`Progress update for job ${jobId} step [${progressData.currentStep}] progress ${progressData.progress}%`);
                     const dataToSend = { ...progressData, type: 'progress' };
                     res.write(`data: ${JSON.stringify(dataToSend)}\n\n`);
+
+                    // Close SSE connection after sending completion or failure events
+                    if (progressData.status === 'completed' || progressData.status === 'failed' || progressData.status === 'cancelled') {
+                        console.log(`Closing SSE connection for job ${jobId} after ${progressData.status} event`);
+                        this.removeListener('progress', onProgress);
+
+                        // Close the connection after a brief delay to ensure the client receives the final event
+                        setTimeout(() => {
+                            try {
+                                res.end();
+                            } catch (error) {
+                                console.warn(`Error closing SSE connection for job ${jobId}:`, error.message);
+                            }
+                        }, 100);
+                    }
                 }
             };
 


### PR DESCRIPTION
### Purpose

- After successfully generating the SDK, the SSE (Server-Sent Events) connection should be closed as it is no longer required.
- This PR introduces the logic to automatically close the SSE connection once the job is finalized.
- **Related to:** [wso2-enterprise/apim-saas#877](https://github.com/wso2-enterprise/apim-saas/issues/877)

### Approach

- Monitor the SDK job status, and if it reaches a terminal state (`completed`, `failed`, or `cancelled`), the SSE connection is closed.