### PR TITLE
Restrict portal theming zip file upload size

### DIFF
--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -450,7 +450,7 @@ const updateOrgContent = async (req, res) => {
             throw new CustomError(400, "Bad Request", "Missing required zip file");
         }
         if (req.file.size > 50 * 1024 * 1024) {
-            throw new CustomError(400, "Bad Request", "File size exceeds the 10MB limit");
+            throw new CustomError(400, "Bad Request", "File size exceeds the 50MB limit");
         }
         await util.unzipDirectory(zipPath, extractPath);
         const files = await util.readFilesInDirectory(extractPath, orgId, req.protocol, req.get('host'), viewName);

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -184,8 +184,8 @@ const unzipDirectory = async (zipPath, extractPath) => {
         throw new CustomError(400, 'Error unzipping directory', 'Invalid zip path or extract path.');
     }
     const extractedFiles = [];
-    const maxFileSize = 50 * 1024 * 1024; // 50MB (limit for individual file size)
-    const maxTotalSize = 100 * 1024 * 1024; // 100MB (limit for total extracted data)
+    const maxFileSize = 10 * 1024 * 1024; // 10MB (limit for individual file size)
+    const maxTotalSize = 50 * 1024 * 1024; // 50MB (limit for total extracted data)
     const maxDepth = 10; // Limit to prevent excessive nesting
     let totalExtractedSize = 0; // Total extracted data size
 
@@ -216,7 +216,7 @@ const unzipDirectory = async (zipPath, extractPath) => {
                             || (totalExtractedSize + entrySize > maxTotalSize)) {
                             entry.autodrain();
                             return reject(new CustomError(400, 'Error unzipping directory'
-                                , 'File size exceeded the limit of 100 MB'));
+                                , 'File size exceeded the limit of 50 MB'));
                         }
 
                         const dirName = path.dirname(normalizedFilePath);


### PR DESCRIPTION
## Purpose
> Restrict the theming file size to 10 MB from the devportal backend

## Issue
> https://github.com/wso2-enterprise/apim-saas/issues/1389