### PR TITLE
Update terminology from "production endpoint" to "main endpoint"

### DIFF
--- a/libs/graphql-schema-viewer/src/components/GraphQLSchemaViewer/GraphQLSchemaViewer.tsx
+++ b/libs/graphql-schema-viewer/src/components/GraphQLSchemaViewer/GraphQLSchemaViewer.tsx
@@ -302,7 +302,7 @@ export const GraphQLSchemaViewer: React.FC<GraphQLSchemaViewerProps> = ({ schema
                   style={styles.endpointCard}
                   role="button"
                   tabIndex={0}
-                  aria-label="Copy production endpoint URL to clipboard"
+                  aria-label="Copy main endpoint URL to clipboard"
                   onMouseEnter={(e) => {
                     e.currentTarget.style.borderColor = '#22863a';
                     e.currentTarget.style.boxShadow = '0 2px 8px rgba(34, 134, 58, 0.15)';

--- a/src/defaultContent/pages/api-landing/partials/api-default.hbs
+++ b/src/defaultContent/pages/api-landing/partials/api-default.hbs
@@ -30,7 +30,7 @@
             {{#unless (eq resources.serverDetails.productionURL "")}}
             <div class="defaultapi-endpoint-row col-12 col-xl-9">
                 <div class="defaultapi-endpoint-content">
-                    <span class="defaultapi-development-label">Production Endpoint</span>
+                    <span class="defaultapi-development-label">Main Endpoint</span>
                     <div class="defaultapi-endpoint-url-container d-flex">
                         <pre id="token_api_prod_url" class="defaultapi-endpoint-url token-text mb-0">{{resources.serverDetails.productionURL}}</pre>
                         <a class="copy-button" aria-label="Copy token" type="button" onclick="copyToken('api_prod_url')">


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated endpoint label terminology from "Production Endpoint" to "Main Endpoint" throughout the interface.
  * Copy button accessibility labels updated to reflect new endpoint naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->