### PR TITLE
Add support for API artifact uploads and enhance import functionality

### DIFF
--- a/docs/AddUpdateWithAPIArtifact.md
+++ b/docs/AddUpdateWithAPIArtifact.md
@@ -1,0 +1,113 @@
+Add/Update API with API Artifact
+==============================
+
+This guide describes how to create or update APIs using a single `apiArtifact` upload.
+
+Supported endpoints
+-------------------
+
+- Create API (org): `POST /devportal/organizations/{organizationID}/apis`
+- Create API (S2S): `POST /devportal/apis`
+- Update API (org): `PUT /devportal/organizations/{organizationID}/apis/{apiID}`
+- Update API (S2S): `PUT /devportal/apis/{apiID}`
+
+Multipart field
+---------------
+
+Use the multipart field below:
+
+- `apiArtifact`: zip file containing metadata, definition, and optional content.
+
+Recommended artifact structure
+------------------------------
+
+```text
+manifest.yaml                       # optional
+devportal-api.yaml                  # required (metadata)
+devportal-api-definition.yaml       # required (API definition)
+docs/                               # optional (markdown docs)
+apiContent/                         # optional (landing files + images)
+```
+
+Optional `manifest.yaml`
+------------------------
+
+Use this only if your artifact uses non-default paths.
+
+```yaml
+apiMetadataPath: devportal-api.yaml
+apiDefinitionPath: devportal-api-definition.yaml
+docsPath: docs
+apiContentPath: apiContent
+```
+
+Sample `devportal-api.yaml`
+---------------------------
+
+```yaml
+apiVersion: devportal.api-platform.wso2.com/v1
+kind: RestApi # RestApi | WS | GraphQL | SOAP | WebSubApi
+
+metadata:
+  name: pizzashack-api-v1.0   # internal API handle
+
+spec:
+  displayName: PizzaShackAPI
+  version: 1.0.0
+  description: This is a simple API for Pizza Shack
+  provider: WSO2
+  # referenceID: <uuid-from-control-plane>
+
+  tags:
+    - pizza
+
+  labels:
+    - default
+
+  subscriptionPolicies:
+    - Gold
+    - Bronze
+
+  visibility: PRIVATE
+  visibleGroups:
+    - HR
+
+  businessInformation:
+    businessOwner: Jane Roe
+    businessOwnerEmail: marketing@pizzashack.com
+    technicalOwner: John Doe
+    technicalOwnerEmail: architecture@pizzashack.com
+
+  endpoints:
+    sandboxUrl: https://sand.example.com/pizzashack/v1/api/
+    productionUrl: https://prod.example.com/pizzashack/v1/api/
+```
+
+Create with artifact (example)
+------------------------------
+
+```bash
+curl --location --request POST 'http://localhost:3000/devportal/organizations/{organizationID}/apis' \
+  --header 'Authorization: Bearer <access_token>' \
+  --form 'apiArtifact=@"{path-to-api-artifact.zip}"'
+```
+
+Update with artifact (example)
+------------------------------
+
+```bash
+curl --location --request PUT 'http://localhost:3000/devportal/organizations/{organizationID}/apis/{apiID}' \
+  --header 'Authorization: Bearer <access_token>' \
+  --form 'apiArtifact=@"{path-to-api-artifact.zip}"'
+```
+
+Update behavior summary
+-----------------------
+
+- Metadata is updated from `devportal-api.yaml`.
+- API definition is updated from `devportal-api-definition.yaml`.
+- Subscription policy mappings are replaced by the artifact values.
+- For docs, API landing content, and images:
+  - if a file/item in the artifact already exists, it is updated
+  - if it does not exist, it is created
+  - if it is not included in the artifact, the existing item is kept as-is (not deleted)

--- a/src/routes/devportalRoute.js
+++ b/src/routes/devportalRoute.js
@@ -58,6 +58,7 @@ router.post(
     multipartHandler.fields([
         {name: 'apiDefinition', maxCount: 1},
         {name: 'schemaDefinition', maxCount: 1},
+        {name: 'apiArtifact', maxCount: 1},
     ]),
     apiMetadataService.createAPIMetadata);
 router.get('/organizations/:orgId/apis/:apiId', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.getAPIMetadata);
@@ -90,6 +91,7 @@ router.post(
     multipartHandler.fields([
         {name: 'apiDefinition', maxCount: 1},
         {name: 'schemaDefinition', maxCount: 1},
+        {name: 'apiArtifact', maxCount: 1},
     ]),
     apiMetadataService.createAPIMetadata); // s2s applied
 router.get('/apis', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.getAllAPIMetadata); // s2s applied

--- a/src/routes/devportalRoute.js
+++ b/src/routes/devportalRoute.js
@@ -69,6 +69,7 @@ router.put(
     multipartHandler.fields([
         {name: 'apiDefinition', maxCount: 1},
         {name: 'schemaDefinition', maxCount: 1},
+        {name: 'apiArtifact', maxCount: 1},
     ]),
     apiMetadataService.updateAPIMetadata);
 router.delete('/organizations/:orgId/apis/:apiId', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.deleteAPIMetadata);
@@ -101,6 +102,7 @@ router.put(
     multipartHandler.fields([
         {name: 'apiDefinition', maxCount: 1},
         {name: 'schemaDefinition', maxCount: 1},
+        {name: 'apiArtifact', maxCount: 1},
     ]),
     apiMetadataService.updateAPIMetadata); // s2s applied
 router.delete('/apis/:apiId', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.deleteAPIMetadata); // s2s applied

--- a/src/services/apiMetadataService.js
+++ b/src/services/apiMetadataService.js
@@ -40,6 +40,15 @@ const createAPIMetadata = async (req, res) => {
     logger.info('Creating API metadata...', {
         orgId
     });
+
+    if (util.isZipFileUpload(req.files?.apiArtifact?.[0])) {
+        logger.info('API artifact ZIP file detected. Routing through API import flow.', {
+            orgId,
+            fileName: req.files.apiArtifact[0].originalname
+        });
+        return importAPIZip(req, res);
+    }
+
     const apiMetadata = JSON.parse(req.body.apiMetadata);
     let apiDefinitionFile, apiFileName = "";
     if (req.files?.apiDefinition?.[0]) {
@@ -484,6 +493,383 @@ const deleteAPIMetadata = async (req, res) => {
             util.handleError(res, error);
         }
     });
+};
+
+const IMPORT_DEFAULTS = constants.API_IMPORT;
+const IMPORT_IMAGE_EXTENSIONS = new Set(constants.API_IMPORT.IMAGE_EXTENSIONS);
+
+const buildImportAPIMetadata = (apiMetadataPayload, apiType) => {
+    const metadata = apiMetadataPayload?.metadata || {};
+    const spec = apiMetadataPayload?.spec || {};
+    const businessInfo = spec.businessInformation || {};
+    const visibility = (spec.visibility || constants.API_VISIBILITY.PUBLIC).toUpperCase();
+
+    if (!metadata.name) {
+        throw new Sequelize.ValidationError("Missing required field: metadata.name in devportal-api.yaml");
+    }
+    if (!spec.displayName) {
+        throw new Sequelize.ValidationError("Missing required field: spec.displayName in devportal-api.yaml");
+    }
+    if (!spec.version) {
+        throw new Sequelize.ValidationError("Missing required field: spec.version in devportal-api.yaml");
+    }
+    if (![constants.API_VISIBILITY.PUBLIC, constants.API_VISIBILITY.PRIVATE].includes(visibility)) {
+        throw new Sequelize.ValidationError("spec.visibility must be either PUBLIC or PRIVATE");
+    }
+    if (labels !== undefined && !Array.isArray(labels)) {
+        throw new Sequelize.ValidationError("spec.labels must be an array");
+    }
+    if (visibleGroups !== undefined && !Array.isArray(visibleGroups)) {
+        throw new Sequelize.ValidationError("spec.visibleGroups must be an array");
+    }
+    if (visibility === constants.API_VISIBILITY.PUBLIC && visibleGroups?.length > 0) {
+        throw new Sequelize.ValidationError(
+            "Visible groups cannot be specified for a public API"
+        );
+    }
+
+    return {
+        apiInfo: {
+            referenceID: spec.referenceID || null,
+            apiStatus: constants.API_STATUS.PUBLISHED,
+            provider: spec.provider || "WSO2",
+            apiName: spec.displayName,
+            apiHandle: metadata.name,
+            apiDescription: spec.description || "",
+            apiVersion: spec.version,
+            apiType,
+            visibility,
+            visibleGroups: Array.isArray(spec.visibleGroups) ? spec.visibleGroups : [],
+            tags: Array.isArray(spec.tags) ? spec.tags : [],
+            labels: Array.isArray(spec.labels) ? spec.labels : undefined,
+            owners: {
+                businessOwner: businessInfo.businessOwner,
+                businessOwnerEmail: businessInfo.businessOwnerEmail,
+                technicalOwner: businessInfo.technicalOwner,
+                technicalOwnerEmail: businessInfo.technicalOwnerEmail,
+            }
+        },
+        endPoints: {
+            sandboxURL: spec.endpoints?.sandboxUrl || "",
+            productionURL: spec.endpoints?.productionUrl || ""
+        },
+        subscriptionPolicies: Array.isArray(spec.subscriptionPolicies)
+            ? spec.subscriptionPolicies
+            : []
+    };
+};
+
+const resolveSubscriptionPolicyMappings = async (orgId, policyNames, apiId, transaction) => {
+    if (!Array.isArray(policyNames) || policyNames.length === 0) {
+        return [];
+    }
+
+    const mappedPolicies = [];
+    for (const policyName of policyNames) {
+        if (typeof policyName !== "string" || !policyName.trim()) {
+            throw new Sequelize.ValidationError("Invalid subscription policy in devportal-api.yaml");
+        }
+        const subscriptionPolicy = await apiDao.getSubscriptionPolicyByName(orgId, policyName, transaction);
+        if (!subscriptionPolicy) {
+            throw new Sequelize.EmptyResultError(`Subscription policy not found: ${policyName}`);
+        }
+        mappedPolicies.push({ apiID: apiId, policyID: subscriptionPolicy.POLICY_ID });
+    }
+    return mappedPolicies;
+};
+
+const readApiDefinitionForImport = async (apiDefinitionPath, apiType) => {
+    const rawContent = await fs.readFile(apiDefinitionPath, constants.CHARSET_UTF8);
+    if (apiType === constants.API_TYPE.GRAPHQL) {
+        return {
+            apiDefinitionFileName: constants.FILE_NAME.API_DEFINITION_GRAPHQL,
+            apiDefinitionContent: rawContent
+        };
+    }
+
+    const parsedDefinition = util.parseStructuredData(rawContent, path.basename(apiDefinitionPath));
+    return {
+        apiDefinitionFileName: constants.FILE_NAME.API_DEFINITION_FILE_NAME,
+        apiDefinitionContent: JSON.stringify(parsedDefinition)
+    };
+};
+
+const buildAPIContentFromImport = async (docsPath, apiContentPath) => {
+    const apiContent = [];
+    const imageMetadata = {};
+    const contentUniquenessCheck = new Set();
+    let docsImported = 0;
+    let apiContentImported = 0;
+    let imagesImported = 0;
+
+    if (docsPath && await util.fileExists(docsPath)) {
+        const docsStat = await fs.stat(docsPath);
+        if (!docsStat.isDirectory()) {
+            throw new Sequelize.ValidationError("Configured docsPath is not a directory");
+        }
+        const docFiles = await util.readDirectoryFilesRecursively(docsPath);
+        for (const docFile of docFiles) {
+            const extension = path.extname(docFile.relativePath).toLowerCase();
+            if (extension !== constants.FILE_EXTENSIONS.MD) {
+                continue;
+            }
+            const fileName = path.basename(docFile.relativePath);
+            const relativeDir = path.dirname(docFile.relativePath).replace(/\\/g, "/");
+            const docTypeSuffix = relativeDir === "." ? "Other" : relativeDir;
+            const docType = `${constants.DOC_TYPES.DOC_ID}${docTypeSuffix}`;
+            const uniquenessKey = `${docType}:${fileName}`;
+            if (contentUniquenessCheck.has(uniquenessKey)) {
+                throw new Sequelize.ValidationError(`Duplicate documentation file found: ${fileName}`);
+            }
+            contentUniquenessCheck.add(uniquenessKey);
+            apiContent.push({
+                fileName,
+                content: await fs.readFile(docFile.absolutePath),
+                type: docType
+            });
+            docsImported++;
+        }
+    }
+
+    if (apiContentPath && await util.fileExists(apiContentPath)) {
+        const apiContentStat = await fs.stat(apiContentPath);
+        if (!apiContentStat.isDirectory()) {
+            throw new Sequelize.ValidationError("Configured apiContentPath is not a directory");
+        }
+        const apiContentFiles = await util.readDirectoryFilesRecursively(apiContentPath);
+        for (const webFile of apiContentFiles) {
+            const fileName = path.basename(webFile.relativePath);
+            const extension = path.extname(fileName).toLowerCase();
+            if (IMPORT_IMAGE_EXTENSIONS.has(extension)) {
+                const uniquenessKey = `${constants.DOC_TYPES.IMAGES}:${fileName}`;
+                if (contentUniquenessCheck.has(uniquenessKey)) {
+                    throw new Sequelize.ValidationError(`Duplicate apiContent image found: ${fileName}`);
+                }
+                contentUniquenessCheck.add(uniquenessKey);
+                apiContent.push({
+                    fileName,
+                    content: await fs.readFile(webFile.absolutePath),
+                    type: constants.DOC_TYPES.IMAGES
+                });
+                imageMetadata[path.parse(fileName).name] = fileName;
+                imagesImported++;
+                continue;
+            }
+
+            const uniquenessKey = `${constants.DOC_TYPES.API_LANDING}:${fileName}`;
+            if (contentUniquenessCheck.has(uniquenessKey)) {
+                throw new Sequelize.ValidationError(`Duplicate apiContent file found: ${fileName}`);
+            }
+            contentUniquenessCheck.add(uniquenessKey);
+            apiContent.push({
+                fileName,
+                content: await fs.readFile(webFile.absolutePath),
+                type: constants.DOC_TYPES.API_LANDING
+            });
+            apiContentImported++;
+        }
+    }
+
+    return {
+        apiContent,
+        imageMetadata,
+        docsImported,
+        apiContentImported,
+        imagesImported,
+    };
+};
+
+const importAPIZip = async (req, res) => {
+    const orgId = req.params.orgId;
+    const uploadedZip = req.file || (req.files?.apiArtifact?.[0] || null);
+    const importId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    let extractPath;
+    let uploadedZipPath = uploadedZip?.path;
+
+    logger.info("Importing API ZIP", {
+        orgId,
+        fileName: uploadedZip?.originalname
+    });
+
+    try {
+        if (!orgId) {
+            throw new Sequelize.ValidationError("Missing required path parameter: orgId");
+        }
+
+        if (!uploadedZipPath && uploadedZip?.buffer) {
+            const safeFileName = (uploadedZip.originalname || 'api-import.zip').replace(/[^a-zA-Z0-9._-]/g, '_');
+            uploadedZipPath = path.join('/tmp', 'api-import', orgId, `${importId}-${safeFileName}`);
+            await fs.mkdir(path.dirname(uploadedZipPath), { recursive: true });
+            await fs.writeFile(uploadedZipPath, uploadedZip.buffer);
+        }
+
+        if (!uploadedZipPath) {
+            throw new Sequelize.ValidationError("Missing zip file. Use multipart field 'apiArtifact'.");
+        }
+
+        extractPath = path.join("/tmp", "api-import", orgId, importId);
+        await fs.mkdir(extractPath, { recursive: true });
+        await util.unzipDirectory(uploadedZipPath, extractPath);
+
+        const archiveRootPath = await util.getArchiveRootPath(extractPath);
+
+        logger.info("Extracted API ZIP", {
+            archiveRootPath,
+            extractPath
+        });
+
+        const importConfig = {
+            apiMetadataPath: IMPORT_DEFAULTS.API_METADATA_PATH,
+            apiDefinitionPath: IMPORT_DEFAULTS.API_DEFINITION_PATH,
+            docsPath: IMPORT_DEFAULTS.DOCS_PATH,
+            apiContentPath: IMPORT_DEFAULTS.API_CONTENT_PATH,
+        };
+
+        const manifestPath = path.join(archiveRootPath, IMPORT_DEFAULTS.MANIFEST_FILE_NAME);
+        if (await util.fileExists(manifestPath)) {
+            const manifestRaw = await fs.readFile(manifestPath, constants.CHARSET_UTF8);
+            const manifest = util.parseStructuredData(manifestRaw, path.basename(manifestPath));
+
+            if (manifest.apiMetadataPath && typeof manifest.apiMetadataPath !== 'string') {
+                throw new Sequelize.ValidationError('manifest.apiMetadataPath must be a string');
+            }
+            if (manifest.apiDefinitionPath && typeof manifest.apiDefinitionPath !== 'string') {
+                throw new Sequelize.ValidationError('manifest.apiDefinitionPath must be a string');
+            }
+            if (manifest.docsPath && typeof manifest.docsPath !== 'string') {
+                throw new Sequelize.ValidationError('manifest.docsPath must be a string');
+            }
+            if (manifest.apiContentPath && typeof manifest.apiContentPath !== 'string') {
+                throw new Sequelize.ValidationError('manifest.apiContentPath must be a string');
+            }
+
+            importConfig.apiMetadataPath = manifest.apiMetadataPath || importConfig.apiMetadataPath;
+            importConfig.apiDefinitionPath = manifest.apiDefinitionPath || importConfig.apiDefinitionPath;
+            importConfig.docsPath = manifest.docsPath || importConfig.docsPath;
+            importConfig.apiContentPath = manifest.apiContentPath || importConfig.apiContentPath;
+        }
+
+        const apiMetadataPath = util.resolvePathInArchive(
+            archiveRootPath,
+            importConfig.apiMetadataPath,
+            IMPORT_DEFAULTS.API_METADATA_PATH
+        );
+        if (!(await util.fileExists(apiMetadataPath))) {
+            throw new Sequelize.ValidationError(`API metadata file not found: ${importConfig.apiMetadataPath}`);
+        }
+
+        const apiMetadataRaw = await fs.readFile(apiMetadataPath, constants.CHARSET_UTF8);
+        const apiMetadataPayload = util.parseStructuredData(apiMetadataRaw, path.basename(apiMetadataPath));
+
+        const apiType = util.toApiTypeFromKind(apiMetadataPayload.kind);
+        const importMetadata = buildImportAPIMetadata(apiMetadataPayload, apiType);
+        const definitionPath = util.resolvePathInArchive(
+            archiveRootPath,
+            importConfig.apiDefinitionPath,
+            IMPORT_DEFAULTS.API_DEFINITION_PATH
+        );
+
+        if (!(await util.fileExists(definitionPath))) {
+            throw new Sequelize.ValidationError(`API definition file not found: ${importConfig.apiDefinitionPath}`);
+        }
+
+        const docsPath = util.resolvePathInArchive(
+            archiveRootPath,
+            importConfig.docsPath,
+            IMPORT_DEFAULTS.DOCS_PATH
+        );
+        const apiContentPath = util.resolvePathInArchive(
+            archiveRootPath,
+            importConfig.apiContentPath,
+            IMPORT_DEFAULTS.API_CONTENT_PATH
+        );
+
+        const {
+            apiDefinitionFileName,
+            apiDefinitionContent,
+        } = await readApiDefinitionForImport(definitionPath, apiType);
+
+        const {
+            apiContent,
+            imageMetadata,
+            docsImported,
+            apiContentImported,
+            imagesImported,
+        } = await buildAPIContentFromImport(docsPath, apiContentPath);
+
+        importMetadata.endPoints.productionURL = changeEndpoint(importMetadata.endPoints.productionURL);
+        importMetadata.endPoints.sandboxURL = changeEndpoint(importMetadata.endPoints.sandboxURL);
+        normalizeGraphQLEndpoints(importMetadata);
+
+        let createdApiId;
+        await sequelize.transaction({ timeout: 60000 }, async (t) => {
+            const createdAPI = await apiDao.createAPIMetadata(orgId, importMetadata, t);
+            createdApiId = createdAPI.dataValues.API_ID;
+
+            const mappedPolicies = await resolveSubscriptionPolicyMappings(orgId,
+                importMetadata.subscriptionPolicies,
+                createdApiId,
+                t);
+            if (mappedPolicies.length > 0) {
+                await apiDao.createAPISubscriptionPolicy(mappedPolicies, createdApiId, t);
+            }
+
+            if (importMetadata.apiInfo.labels) {
+                await apiDao.createAPILabelMapping(orgId, createdApiId, importMetadata.apiInfo.labels, t);
+            } else {
+                await apiDao.createAPILabelMapping(orgId, createdApiId, ['default'], t);
+            }
+
+            await apiDao.storeAPIFile(
+                apiDefinitionContent,
+                apiDefinitionFileName,
+                createdApiId,
+                constants.DOC_TYPES.API_DEFINITION,
+                t
+            );
+
+            if (Object.keys(imageMetadata).length > 0) {
+                await apiDao.storeAPIImageMetadata(imageMetadata, createdApiId, t);
+            }
+            if (apiContent.length > 0) {
+                await apiDao.storeAPIFiles(apiContent, createdApiId, t);
+            }
+        });
+
+        res.status(201).send({
+            apiID: createdApiId,
+            apiHandle: importMetadata.apiInfo.apiHandle,
+            message: "API imported successfully",
+            imported: {
+                docs: docsImported,
+                apiContent: apiContentImported,
+                images: imagesImported
+            }
+        });
+    } catch (error) {
+        logger.error("API import failed", {
+            orgId,
+            fileName: uploadedZip?.originalname,
+            error: error.message,
+            stack: error.stack,
+        });
+        util.handleError(res, error);
+    } finally {
+        try {
+            if (extractPath) {
+                await fs.rm(extractPath, { recursive: true, force: true });
+            }
+        } catch (_cleanupError) {
+            logger.warn("Failed to clean import extraction directory", { extractPath });
+        }
+        if (uploadedZipPath) {
+            try {
+                await fs.unlink(uploadedZipPath);
+            } catch (_cleanupError) {
+                logger.warn("Failed to clean uploaded import ZIP", { uploadedPath: uploadedZipPath });
+            }
+        }
+    }
 };
 
 const createAPITemplate = async (req, res) => {
@@ -1345,6 +1731,7 @@ const getViewsFromDB = async (orgId) => {
 
 module.exports = {
     createAPIMetadata,
+    importAPIZip,
     getAPIMetadata,
     getAllAPIMetadata,
     updateAPIMetadata,

--- a/src/services/apiMetadataService.js
+++ b/src/services/apiMetadataService.js
@@ -42,11 +42,11 @@ const createAPIMetadata = async (req, res) => {
     });
 
     if (util.isZipFileUpload(req.files?.apiArtifact?.[0])) {
-        logger.info('API artifact ZIP file detected. Routing through API import flow.', {
+        logger.info('API artifact file detected. Routing through API artifact import flow.', {
             orgId,
             fileName: req.files.apiArtifact[0].originalname
         });
-        return importAPIZip(req, res);
+        return importWithAPIArtifact(req, res);
     }
 
     const apiMetadata = JSON.parse(req.body.apiMetadata);
@@ -318,6 +318,16 @@ const updateAPIMetadata = async (req, res) => {
         orgId,
         apiId
     });
+
+    if (util.isZipFileUpload(req.files?.apiArtifact?.[0])) {
+        logger.info('API artifact file detected. Routing through API artifact update flow.', {
+            orgId,
+            apiId,
+            fileName: req.files.apiArtifact[0].originalname
+        });
+        return updateWithAPIArtifact(req, res);
+    }
+
     const apiMetadata = JSON.parse(req.body.apiMetadata);
     let apiDefinitionFile, apiFileName = "";
     if (req.files?.apiDefinition?.[0]) {
@@ -503,6 +513,8 @@ const buildImportAPIMetadata = (apiMetadataPayload, apiType) => {
     const spec = apiMetadataPayload?.spec || {};
     const businessInfo = spec.businessInformation || {};
     const visibility = (spec.visibility || constants.API_VISIBILITY.PUBLIC).toUpperCase();
+    const labels = spec.labels;
+    const visibleGroups = spec.visibleGroups;
 
     if (!metadata.name) {
         throw new Sequelize.ValidationError("Missing required field: metadata.name in devportal-api.yaml");
@@ -539,9 +551,9 @@ const buildImportAPIMetadata = (apiMetadataPayload, apiType) => {
             apiVersion: spec.version,
             apiType,
             visibility,
-            visibleGroups: Array.isArray(spec.visibleGroups) ? spec.visibleGroups : [],
+            visibleGroups,
             tags: Array.isArray(spec.tags) ? spec.tags : [],
-            labels: Array.isArray(spec.labels) ? spec.labels : undefined,
+            labels: Array.isArray(labels) ? labels : undefined,
             owners: {
                 businessOwner: businessInfo.businessOwner,
                 businessOwnerEmail: businessInfo.businessOwnerEmail,
@@ -679,16 +691,16 @@ const buildAPIContentFromImport = async (docsPath, apiContentPath) => {
     };
 };
 
-const importAPIZip = async (req, res) => {
+const importWithAPIArtifact = async (req, res) => {
     const orgId = req.params.orgId;
-    const uploadedZip = req.file || (req.files?.apiArtifact?.[0] || null);
+    const uploadedArtifact = req.file || (req.files?.apiArtifact?.[0] || null);
     const importId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
     let extractPath;
-    let uploadedZipPath = uploadedZip?.path;
+    let uploadedArtifactPath = uploadedArtifact?.path;
 
-    logger.info("Importing API ZIP", {
+    logger.info("Importing API artifact", {
         orgId,
-        fileName: uploadedZip?.originalname
+        fileName: uploadedArtifact?.originalname
     });
 
     try {
@@ -696,24 +708,24 @@ const importAPIZip = async (req, res) => {
             throw new Sequelize.ValidationError("Missing required path parameter: orgId");
         }
 
-        if (!uploadedZipPath && uploadedZip?.buffer) {
-            const safeFileName = (uploadedZip.originalname || 'api-import.zip').replace(/[^a-zA-Z0-9._-]/g, '_');
-            uploadedZipPath = path.join('/tmp', 'api-import', orgId, `${importId}-${safeFileName}`);
-            await fs.mkdir(path.dirname(uploadedZipPath), { recursive: true });
-            await fs.writeFile(uploadedZipPath, uploadedZip.buffer);
+        if (!uploadedArtifactPath && uploadedArtifact?.buffer) {
+            const safeFileName = (uploadedArtifact.originalname || 'api-import.zip').replace(/[^a-zA-Z0-9._-]/g, '_');
+            uploadedArtifactPath = path.join('/tmp', 'api-import', orgId, `${importId}-${safeFileName}`);
+            await fs.mkdir(path.dirname(uploadedArtifactPath), { recursive: true });
+            await fs.writeFile(uploadedArtifactPath, uploadedArtifact.buffer);
         }
 
-        if (!uploadedZipPath) {
-            throw new Sequelize.ValidationError("Missing zip file. Use multipart field 'apiArtifact'.");
+        if (!uploadedArtifactPath) {
+            throw new Sequelize.ValidationError("Missing API artifact file. Use multipart field 'apiArtifact'.");
         }
 
         extractPath = path.join("/tmp", "api-import", orgId, importId);
         await fs.mkdir(extractPath, { recursive: true });
-        await util.unzipDirectory(uploadedZipPath, extractPath);
+        await util.unzipDirectory(uploadedArtifactPath, extractPath);
 
         const archiveRootPath = await util.getArchiveRootPath(extractPath);
 
-        logger.info("Extracted API ZIP", {
+        logger.info("Extracted API artifact", {
             archiveRootPath,
             extractPath
         });
@@ -849,7 +861,7 @@ const importAPIZip = async (req, res) => {
     } catch (error) {
         logger.error("API import failed", {
             orgId,
-            fileName: uploadedZip?.originalname,
+            fileName: uploadedArtifact?.originalname,
             error: error.message,
             stack: error.stack,
         });
@@ -862,11 +874,211 @@ const importAPIZip = async (req, res) => {
         } catch (_cleanupError) {
             logger.warn("Failed to clean import extraction directory", { extractPath });
         }
-        if (uploadedZipPath) {
+        if (uploadedArtifactPath) {
             try {
-                await fs.unlink(uploadedZipPath);
+                await fs.unlink(uploadedArtifactPath);
             } catch (_cleanupError) {
-                logger.warn("Failed to clean uploaded import ZIP", { uploadedPath: uploadedZipPath });
+                logger.warn("Failed to clean uploaded import artifact", { uploadedPath: uploadedArtifactPath });
+            }
+        }
+    }
+};
+
+const updateWithAPIArtifact = async (req, res) => {
+    const { orgId, apiId } = req.params;
+    const uploadedArtifact = req.file || (req.files?.apiArtifact?.[0] || null);
+    const importId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    let extractPath;
+    let uploadedArtifactPath = uploadedArtifact?.path;
+
+    logger.info("Updating API with artifact", {
+        orgId,
+        apiId,
+        fileName: uploadedArtifact?.originalname
+    });
+
+    try {
+        if (!orgId || !apiId) {
+            throw new Sequelize.ValidationError("Missing required path parameters: orgId and apiId");
+        }
+
+        if (!uploadedArtifactPath && uploadedArtifact?.buffer) {
+            const safeFileName = (uploadedArtifact.originalname || 'api-update.zip').replace(/[^a-zA-Z0-9._-]/g, '_');
+            uploadedArtifactPath = path.join('/tmp', 'api-import', orgId, `${importId}-${safeFileName}`);
+            await fs.mkdir(path.dirname(uploadedArtifactPath), { recursive: true });
+            await fs.writeFile(uploadedArtifactPath, uploadedArtifact.buffer);
+        }
+
+        if (!uploadedArtifactPath) {
+            throw new Sequelize.ValidationError("Missing API artifact file. Use multipart field 'apiArtifact'.");
+        }
+
+        extractPath = path.join("/tmp", "api-import", orgId, importId);
+        await fs.mkdir(extractPath, { recursive: true });
+        await util.unzipDirectory(uploadedArtifactPath, extractPath);
+
+        const archiveRootPath = await util.getArchiveRootPath(extractPath);
+
+        const importConfig = {
+            apiMetadataPath: IMPORT_DEFAULTS.API_METADATA_PATH,
+            apiDefinitionPath: IMPORT_DEFAULTS.API_DEFINITION_PATH,
+            docsPath: IMPORT_DEFAULTS.DOCS_PATH,
+            apiContentPath: IMPORT_DEFAULTS.API_CONTENT_PATH,
+        };
+
+        const manifestPath = path.join(archiveRootPath, IMPORT_DEFAULTS.MANIFEST_FILE_NAME);
+        if (await util.fileExists(manifestPath)) {
+            const manifestRaw = await fs.readFile(manifestPath, constants.CHARSET_UTF8);
+            const manifest = util.parseStructuredData(manifestRaw, path.basename(manifestPath));
+
+            if (manifest.apiMetadataPath && typeof manifest.apiMetadataPath !== 'string') {
+                throw new Sequelize.ValidationError('manifest.apiMetadataPath must be a string');
+            }
+            if (manifest.apiDefinitionPath && typeof manifest.apiDefinitionPath !== 'string') {
+                throw new Sequelize.ValidationError('manifest.apiDefinitionPath must be a string');
+            }
+            if (manifest.docsPath && typeof manifest.docsPath !== 'string') {
+                throw new Sequelize.ValidationError('manifest.docsPath must be a string');
+            }
+            if (manifest.apiContentPath && typeof manifest.apiContentPath !== 'string') {
+                throw new Sequelize.ValidationError('manifest.apiContentPath must be a string');
+            }
+
+            importConfig.apiMetadataPath = manifest.apiMetadataPath || importConfig.apiMetadataPath;
+            importConfig.apiDefinitionPath = manifest.apiDefinitionPath || importConfig.apiDefinitionPath;
+            importConfig.docsPath = manifest.docsPath || importConfig.docsPath;
+            importConfig.apiContentPath = manifest.apiContentPath || importConfig.apiContentPath;
+        }
+
+        const apiMetadataPath = util.resolvePathInArchive(
+            archiveRootPath,
+            importConfig.apiMetadataPath,
+            IMPORT_DEFAULTS.API_METADATA_PATH
+        );
+        if (!(await util.fileExists(apiMetadataPath))) {
+            throw new Sequelize.ValidationError(`API metadata file not found: ${importConfig.apiMetadataPath}`);
+        }
+
+        const apiMetadataRaw = await fs.readFile(apiMetadataPath, constants.CHARSET_UTF8);
+        const apiMetadataPayload = util.parseStructuredData(apiMetadataRaw, path.basename(apiMetadataPath));
+
+        const apiType = util.toApiTypeFromKind(apiMetadataPayload.kind);
+        const importMetadata = buildImportAPIMetadata(apiMetadataPayload, apiType);
+
+        const definitionPath = util.resolvePathInArchive(
+            archiveRootPath,
+            importConfig.apiDefinitionPath,
+            IMPORT_DEFAULTS.API_DEFINITION_PATH
+        );
+        if (!(await util.fileExists(definitionPath))) {
+            throw new Sequelize.ValidationError(`API definition file not found: ${importConfig.apiDefinitionPath}`);
+        }
+
+        const docsPath = util.resolvePathInArchive(
+            archiveRootPath,
+            importConfig.docsPath,
+            IMPORT_DEFAULTS.DOCS_PATH
+        );
+        const apiContentPath = util.resolvePathInArchive(
+            archiveRootPath,
+            importConfig.apiContentPath,
+            IMPORT_DEFAULTS.API_CONTENT_PATH
+        );
+
+        const {
+            apiDefinitionFileName,
+            apiDefinitionContent,
+        } = await readApiDefinitionForImport(definitionPath, apiType);
+
+        const {
+            apiContent,
+            imageMetadata,
+            docsImported,
+            apiContentImported,
+            imagesImported,
+        } = await buildAPIContentFromImport(docsPath, apiContentPath);
+
+        importMetadata.endPoints.productionURL = changeEndpoint(importMetadata.endPoints.productionURL);
+        importMetadata.endPoints.sandboxURL = changeEndpoint(importMetadata.endPoints.sandboxURL);
+        normalizeGraphQLEndpoints(importMetadata);
+
+        await sequelize.transaction({ timeout: 60000 }, async (t) => {
+            const [updatedRows] = await apiDao.updateAPIMetadata(orgId, apiId, importMetadata, t);
+            if (!updatedRows) {
+                throw new Sequelize.EmptyResultError("No record found to update");
+            }
+
+            if (importMetadata.subscriptionPolicies) {
+                const mappedPolicies = await resolveSubscriptionPolicyMappings(orgId,
+                    importMetadata.subscriptionPolicies,
+                    apiId,
+                    t);
+                await apiDao.updateAPISubscriptionPolicy(mappedPolicies, apiId, t);
+            }
+
+            if (importMetadata.apiInfo.labels !== undefined) {
+                const existingMetadata = await apiDao.getAPIMetadata(orgId, apiId, t);
+                const existingLabels = existingMetadata?.[0]?.DP_LABELs
+                    ? existingMetadata[0].DP_LABELs.map((label) => label.dataValues ? label.dataValues.NAME : label.NAME)
+                    : [];
+
+                if (existingLabels.length > 0) {
+                    await apiDao.deleteAPILabels(orgId, apiId, existingLabels, t);
+                }
+                if (importMetadata.apiInfo.labels.length > 0) {
+                    await apiDao.createAPILabelMapping(orgId, apiId, importMetadata.apiInfo.labels, t);
+                }
+            }
+
+            await apiDao.updateAPIFile(
+                apiDefinitionContent,
+                apiDefinitionFileName,
+                apiId,
+                orgId,
+                constants.DOC_TYPES.API_DEFINITION,
+                t
+            );
+
+            if (Object.keys(imageMetadata).length > 0) {
+                await apiDao.updateAPIImageMetadata(imageMetadata, orgId, apiId, t);
+            }
+            if (apiContent.length > 0) {
+                await apiDao.updateOrCreateAPIFiles(apiContent, apiId, orgId, t);
+            }
+        });
+
+        res.status(200).send({
+            apiID: apiId,
+            apiHandle: importMetadata.apiInfo.apiHandle,
+            message: "API updated successfully",
+            imported: {
+                docs: docsImported,
+                apiContent: apiContentImported,
+                images: imagesImported
+            }
+        });
+    } catch (error) {
+        logger.error("API artifact update failed", {
+            orgId,
+            apiId,
+            fileName: uploadedArtifact?.originalname,
+            error: error.message,
+            stack: error.stack,
+        });
+        util.handleError(res, error);
+    } finally {
+        try {
+            if (extractPath) {
+                await fs.rm(extractPath, { recursive: true, force: true });
+            }
+        } catch (_cleanupError) {
+            logger.warn("Failed to clean update extraction directory", { extractPath });
+        }
+        if (uploadedArtifactPath) {
+            try {
+                await fs.unlink(uploadedArtifactPath);
+            } catch (_cleanupError) {
+                logger.warn("Failed to clean uploaded update artifact", { uploadedPath: uploadedArtifactPath });
             }
         }
     }
@@ -1731,7 +1943,8 @@ const getViewsFromDB = async (orgId) => {
 
 module.exports = {
     createAPIMetadata,
-    importAPIZip,
+    importWithAPIArtifact,
+    updateWithAPIArtifact,
     getAPIMetadata,
     getAllAPIMetadata,
     updateAPIMetadata,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -44,6 +44,8 @@ module.exports = {
         UNPUBLISHED: "CREATED"
     },
     API_TYPE: {
+        REST: "REST",
+        SOAP: "SOAP",
         MCP: "MCP",
         MCP_ONLY: "MCPSERVERSONLY",
         API_PROXIES: "APISONLY",
@@ -74,6 +76,9 @@ module.exports = {
         HTML: 'text/html',
         TEXT: 'text/plain',
         JSON: 'application/json',
+        ZIP: 'application/zip',
+        ZIP_COMPRESSED: 'application/x-zip-compressed',
+        ZIP_MULTIPART: 'multipart/x-zip',
         YAML: 'application/x-yaml',
         XML: 'application/xml',
         CSS: 'text/css',
@@ -170,6 +175,14 @@ module.exports = {
         API_SPECIFICATION_PATH: 'specification',
         API_DEFINITION_GRAPHQL: 'apiDefinition.graphql',
         API_DEFINITION_XML: 'apiDefinition.xml',
+    },
+    API_IMPORT: {
+        MANIFEST_FILE_NAME: './manifest.yaml',
+        API_METADATA_PATH: './devportal-api.yaml',
+        API_DEFINITION_PATH: './devportal-api-definition.yaml',
+        DOCS_PATH: './docs',
+        API_CONTENT_PATH: './apiContent',
+        IMAGE_EXTENSIONS: ['.svg', '.jpg', '.jpeg', '.png', '.gif']
     },
     DEFAULT_SUBSCRIPTION_PLANS: [
         {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -34,6 +34,7 @@ const { Sequelize } = require('sequelize');
 const apiDao = require('../dao/apiMetadata');
 const subscriptionPolicyDTO = require('../dto/subscriptionPolicy');
 const jwt = require('jsonwebtoken');
+const yaml = require('js-yaml');
 const filePrefix = '/src/defaultContent/';
 
 // Function to load and convert markdown file to HTML
@@ -257,6 +258,38 @@ const unzipDirectory = async (zipPath, extractPath) => {
     }).catch((err) => {
         throw err;
     });
+}
+
+// Detect whether an uploaded multipart file is a ZIP artifact.
+function isZipFileUpload(file) {
+    if (!file) {
+        return false;
+    }
+
+    const fileName = (file.originalname || '').toLowerCase();
+    const mimeType = (file.mimetype || '').toLowerCase();
+    return fileName.endsWith('.zip')
+        || mimeType === constants.MIME_TYPES.ZIP
+        || mimeType === constants.MIME_TYPES.ZIP_COMPRESSED
+        || mimeType === constants.MIME_TYPES.ZIP_MULTIPART;
+}
+
+// Map imported API `kind` values to internal API type constants.
+function toApiTypeFromKind(kind) {
+    switch ((kind || '').toLowerCase()) {
+        case 'restapi':
+            return constants.API_TYPE.REST;
+        case 'ws':
+            return constants.API_TYPE.WS;
+        case 'graphql':
+            return constants.API_TYPE.GRAPHQL;
+        case 'soap':
+            return constants.API_TYPE.SOAP;
+        case 'websubapi':
+            return constants.API_TYPE.WEBSUB;
+        default:
+            throw new Sequelize.ValidationError(`Unsupported API kind: ${kind}`);
+    }
 }
 
 const imageMapping = {
@@ -657,6 +690,95 @@ const rejectExtraProperties = (allowedKeys, payload) => {
     return extraKeys;
 };
 
+// Returns true when a file or directory exists on disk.
+const fileExists = async (targetPath) => {
+    try {
+        await fs.promises.access(targetPath);
+        return true;
+    } catch (_error) {
+        return false;
+    }
+};
+
+// Checks whether a target path is inside a given base directory.
+const isPathWithinBase = (basePath, targetPath) => {
+    const normalizedBasePath = path.resolve(basePath);
+    const normalizedTargetPath = path.resolve(targetPath);
+    return normalizedTargetPath === normalizedBasePath
+        || normalizedTargetPath.startsWith(`${normalizedBasePath}${path.sep}`);
+};
+
+// Resolves a configured (or default) archive-relative path and blocks path traversal.
+const resolvePathInArchive = (basePath, configuredPath, defaultPath) => {
+    const relativePath = configuredPath || defaultPath;
+    const resolvedPath = path.resolve(basePath, relativePath);
+    if (!isPathWithinBase(basePath, resolvedPath)) {
+        throw new Sequelize.ValidationError(`Invalid import path: ${relativePath}. Path must stay within the extracted archive.`);
+    }
+    return resolvedPath;
+};
+
+// Detects if the archive was created with a single top-level folder (e.g., MyAPI/) and returns that as the root.
+const getArchiveRootPath = async (extractedPath) => {
+    const entries = await fs.promises.readdir(extractedPath, { withFileTypes: true });
+    const visibleEntries = entries.filter((entry) => entry.name !== '.DS_Store' && entry.name !== '__MACOSX');
+
+    if (visibleEntries.length === 1 && visibleEntries[0].isDirectory()) {
+        return path.join(extractedPath, visibleEntries[0].name);
+    }
+
+    return extractedPath;
+};
+
+// Recursively reads files from a directory while rejecting traversal and symbolic links.
+const readDirectoryFilesRecursively = async (directory, baseDirectory = directory) => {
+    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+    const files = [];
+
+    for (const entry of entries) {
+        if (entry.name === '.DS_Store') {
+            continue;
+        }
+
+        const absolutePath = path.resolve(path.join(directory, entry.name));
+        if (!isPathWithinBase(baseDirectory, absolutePath)) {
+            throw new Sequelize.ValidationError(`Invalid file path in archive: ${entry.name}`);
+        }
+
+        const stat = await fs.promises.lstat(absolutePath);
+        if (stat.isSymbolicLink()) {
+            throw new Sequelize.ValidationError(`Symbolic links are not allowed in archive: ${entry.name}`);
+        }
+
+        if (entry.isDirectory()) {
+            files.push(...await readDirectoryFilesRecursively(absolutePath, baseDirectory));
+        } else {
+            files.push({
+                absolutePath,
+                relativePath: path.relative(baseDirectory, absolutePath).replace(/\\/g, '/')
+            });
+        }
+    }
+    return files;
+};
+
+// Parses JSON first, then YAML, and returns a plain object payload.
+const parseStructuredData = (rawContent, sourceName = 'content') => {
+    try {
+        return JSON.parse(rawContent);
+    } catch (_jsonError) {
+        try {
+            const parsed = yaml.load(rawContent);
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                throw new Error('Parsed content is not a valid object');
+            }
+            return parsed;
+        } catch (yamlError) {
+            throw new Sequelize.ValidationError(`Failed to parse ${sourceName}: ${yamlError.message}`);
+        }
+    }
+};
+
 async function readFilesInDirectory(directory, orgId, protocol, host, viewName, baseDir = '') {
     try {
         const files = await fs.promises.readdir(directory, { withFileTypes: true });
@@ -949,6 +1071,8 @@ module.exports = {
     renderTemplateFromAPI,
     renderGivenTemplate,
     handleError,
+    isZipFileUpload,
+    toApiTypeFromKind,
     retrieveContentType,
     getAPIFileContent,
     getAPIImages,
@@ -962,6 +1086,11 @@ module.exports = {
     getErrors,
     validateProvider,
     validateRequestParameters,
+    parseStructuredData,
+    fileExists,
+    resolvePathInArchive,
+    getArchiveRootPath,
+    readDirectoryFilesRecursively,
     rejectExtraProperties,
     readFilesInDirectory,
     appendAPIImageURL,


### PR DESCRIPTION
## Purpose
Enable users to import an API into the Developer Portal using a ZIP file that contains the all the related content.

## Approach
Extended the existing POST /apis flow to detect and process API artifact uploads via multipart `apiArtifact` input, while preserving the existing metadata+definition path.

Also added artifact-based update support in PUT /apis/:apiId (and org-scoped equivalents), reusing the same artifact parsing/import logic.

Allowed API artifact ZIP structure 
- manifest.yaml (optional path overrides)
- devportal-api.yaml (required)
- devportal-api-definition.yaml (required)
- docs/ (optional)
- apiContent/ (optional)

Refer to the newly added doc for more info on this
