### PR TITLE
Revert "Add support to invoke control plane to revoke subscriptions"

### DIFF
--- a/sample_config.json
+++ b/sample_config.json
@@ -16,12 +16,7 @@
     },
     "disabledRoleValidation": true,
     "disableOrgCallback": true,
-    "disableScopeValidation": true,
-    "tokenExchanger": {
-      "enabled": false,
-      "url": "<TOKEN_EXCHANGER_URL>"
-    },
-    "devportalApimSPClientId": "<DP_APIM_SP_CLIENT_ID>"
+    "disableScopeValidation": true
   },
   "pathToContent": "./resources/default-layout/",
   "pathToDBCert": "./resources/security/ca.pem",

--- a/sample_secret.json
+++ b/sample_secret.json
@@ -7,6 +7,5 @@
         "apiKey": "<API_KEY>"
     },
     "azureInsightsConnectionString": "<AZURE_INSIGHTS_CONNECTION_STRING>",
-    "redisSecret": "<REDIS_SECRET>",
-    "devportalApimSPClientSecret": "<DP_APIM_SP_CLIENT_SECRET>"
+    "redisSecret": "<REDIS_SECRET>"
 }

--- a/src/dao/admin.js
+++ b/src/dao/admin.js
@@ -830,19 +830,6 @@ const deleteAppMappings = async (orgID, appID, t) => {
     }
 }
 
-const deleteAppKeyMappingBySubscriptionRef = async (orgId, subscriptionRefId) => {
-    try {
-        return await ApplicationKeyMapping.destroy({
-            where: {
-                ORG_ID: orgId,
-                SUBSCRIPTION_REF_ID: subscriptionRefId
-            }
-        });
-    } catch (error) {
-        throw new Sequelize.DatabaseError(error);
-    }
-}
-
 const getAPISubscriptionReference = async (orgID, appID, apiID, t) => {
     try {
         const subscriptionReference = await ApplicationKeyMapping.findAll(
@@ -1311,37 +1298,6 @@ const getSubscriptionWithMeter = async (orgID, subID, t) => {
     }
 };
 
-/**
- * Get CP subscription ref ID and org identifier by Stripe billing subscription ID.
- */
-const getSubscriptionRefByBillingSubscriptionId = async (billingSubscriptionId) => {
-    try {
-        if (!billingSubscriptionId) throw new Sequelize.ValidationError('billingSubscriptionId is required');
-        const sequelize = require('../db/sequelize');
-        const results = await sequelize.query(
-            `
-            SELECT
-                akm."SUBSCRIPTION_REF_ID" as "subscriptionRefId",
-                o."ORGANIZATION_IDENTIFIER" as "orgIdentifier",
-                s."ORG_ID" as "orgId"
-            FROM "DP_API_SUBSCRIPTION" s
-            LEFT JOIN "DP_API_METADATA" a ON s."API_ID" = a."API_ID" AND s."ORG_ID" = a."ORG_ID"
-            LEFT JOIN "DP_APP_KEY_MAPPING" akm
-                ON akm."APP_ID" = s."APP_ID"
-                AND akm."API_REF_ID" = a."REFERENCE_ID"
-                AND akm."ORG_ID" = s."ORG_ID"
-            LEFT JOIN "DP_ORGANIZATION" o ON s."ORG_ID" = o."ORG_ID"
-            WHERE s."BILLING_SUBSCRIPTION_ID" = :billingSubscriptionId
-            LIMIT 1
-            `,
-            { replacements: { billingSubscriptionId }, type: sequelize.QueryTypes.SELECT },
-        );
-        return results?.[0] || null;
-    } catch (error) {
-        throw new Sequelize.DatabaseError(error);
-    }
-};
-
 module.exports = {
     createOrganization,
     getOrganization,
@@ -1398,6 +1354,4 @@ module.exports = {
     getAPIById,
     getSubscriptionPolicyById,
     getSubscriptionWithMeter,
-    getSubscriptionRefByBillingSubscriptionId,
-    deleteAppKeyMappingBySubscriptionRef,
 };

--- a/src/services/monetizationService.js
+++ b/src/services/monetizationService.js
@@ -50,10 +50,8 @@ const constants = require("../utils/constants");
 const stripeService = require("./stripeService");
 const { getDecryptedStripeKeysForOrg } = require("./orgBillingKeyService");
 const moesifService = require("./moesifService");
-const { invokeApiRequest, apiRequest } = require("../utils/util");
+const { invokeApiRequest } = require("../utils/util");
 const config = require(process.cwd() + "/config.json");
-const secret = require(process.cwd() + "/secret.json");
-const axios = require("axios");
 
 const controlPlaneUrl = config.controlPlane.url;
 
@@ -68,42 +66,6 @@ const PAYMENT_STATUS = {
   CANCELED: "CANCELED",
   PAST_DUE: "PAST_DUE",
 };
-
-/**
- * Obtain a CP service token via client_credentials grant using the devportalApimSP
- * service principal. Used for server-to-server CP calls from webhook handlers
- * where there is no user session available.
- */
-async function getCPServiceToken() {
-  const clientId = config.advanced?.devportalApimSPClientId;
-  const clientSecret = secret?.devportalApimSPClientSecret;
-  if (!clientId || !clientSecret) {
-    throw new Error(
-      "CP service principal not configured: devportalApimSPClientId / devportalApimSPClientSecret missing",
-    );
-  }
-  const tokenUrl = config.advanced?.tokenExchanger?.url;
-  if (!tokenUrl) {
-    throw new Error("CP service token URL not configured: config.advanced.tokenExchanger.url missing");
-  }
-  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
-  const response = await axios.post(
-    tokenUrl,
-    "grant_type=client_credentials&scope=apim%3Aadmin",
-    {
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Authorization: `Basic ${credentials}`,
-      },
-      timeout: 10000,
-    },
-  );
-  const accessToken = response.data?.access_token;
-  if (!accessToken) {
-    throw new Error("CP service token response did not contain access_token");
-  }
-  return accessToken;
-}
 
 /**
  * Returns true if the policy requires payment (BILLING_PLAN !== 'FREE').
@@ -866,66 +828,8 @@ async function handleStripeWebhook(req, orgId) {
     webhookSecret,
   );
   logger.info("handleStripeWebhook: event verified", { orgId, eventType: event?.type });
-  const webhookResult = await stripeService.applyWebhookToLocalState(event, { adminDao });
+  await stripeService.applyWebhookToLocalState(event, { adminDao });
   logger.info("handleStripeWebhook: event processed", { orgId, eventType: event?.type });
-
-  if (webhookResult?.newStatus === PAYMENT_STATUS.CANCELED && webhookResult?.stripeSubscriptionId) {
-    setImmediate(() => {
-      (async () => {
-        try {
-          const subRef = webhookResult.subRef;
-          const cpClientId = config.advanced?.devportalApimSPClientId;
-          const cpClientSecret = secret?.devportalApimSPClientSecret;
-          if (!cpClientId || !cpClientSecret) {
-            logger.warn("handleStripeWebhook: CP service principal not configured, skipping CP delete", { orgId });
-            return;
-          }
-          if (subRef?.subscriptionRefId && subRef?.orgIdentifier) {
-            const token = await getCPServiceToken();
-            await apiRequest(
-              "DELETE",
-              `${controlPlaneUrl}/subscriptions/${subRef.subscriptionRefId}`,
-              { Authorization: `Bearer ${token}` },
-              null,
-              subRef.orgIdentifier,
-            );
-            logger.info("handleStripeWebhook: CP subscription deleted", {
-              orgId,
-              subscriptionRefId: subRef.subscriptionRefId,
-              eventType: event?.type,
-            });
-            try {
-              await adminDao.deleteAppKeyMappingBySubscriptionRef(subRef.orgId, subRef.subscriptionRefId);
-              logger.info("handleStripeWebhook: app key mapping deleted", {
-                orgId,
-                subscriptionRefId: subRef.subscriptionRefId,
-              });
-            } catch (mappingErr) {
-              logger.warn("handleStripeWebhook: app key mapping delete failed (non-fatal)", {
-                orgId,
-                subscriptionRefId: subRef.subscriptionRefId,
-                err: mappingErr.message,
-              });
-            }
-          } else {
-            logger.warn("handleStripeWebhook: no CP subscription ref found, skipping CP delete", {
-              orgId,
-              stripeSubscriptionId: webhookResult.stripeSubscriptionId,
-            });
-          }
-        } catch (cpErr) {
-          logger.warn("handleStripeWebhook: CP subscription deletion failed (non-fatal)", {
-            orgId,
-            stripeSubscriptionId: webhookResult.stripeSubscriptionId,
-            err: cpErr.message,
-          });
-        }
-      })().catch((err) =>
-        logger.warn("handleStripeWebhook: CP cleanup promise rejected", { orgId, err: err.message }),
-      );
-    });
-  }
-
   return true;
 }
 

--- a/src/services/stripeService.js
+++ b/src/services/stripeService.js
@@ -18,7 +18,6 @@
  */
 
 const StripeSDK = require("stripe");
-const Sequelize = require("sequelize");
 const { CustomError } = require("../utils/errors/customErrors");
 const logger = require("../config/logger");
 
@@ -270,20 +269,9 @@ async function applyWebhookToLocalState(event, { adminDao }) {
       newStatus = PAYMENT_STATUS.PAYMENT_FAILED;
       break;
 
-    case "customer.subscription.deleted": {
-      const subRef = await adminDao.getSubscriptionRefByBillingSubscriptionId(stripeSubscriptionId);
-      try {
-        await adminDao.deleteSubscriptionByBillingId(stripeSubscriptionId);
-      } catch (err) {
-        if (err instanceof Sequelize.EmptyResultError) {
-          // Row already deleted by a prior delivery — treat as idempotent success.
-          logger.info("applyWebhookToLocalState: subscription already deleted, skipping", { stripeSubscriptionId });
-        } else {
-          throw err;
-        }
-      }
-      return { newStatus: PAYMENT_STATUS.CANCELED, stripeSubscriptionId, eventType, subRef };
-    }
+    case "customer.subscription.deleted":
+      newStatus = PAYMENT_STATUS.CANCELED;
+      break;
 
     case "customer.subscription.updated": {
       const sub = event?.data?.object;


### PR DESCRIPTION
Reverts wso2/api-developer-portal-core#655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused configuration entries for token exchange integration and developer portal client credentials from sample configuration and secrets files.

* **Refactor**
  * Simplified subscription cancellation event processing by removing legacy asynchronous control-plane operations; the system now only updates local subscription payment status without performing external cleanup actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->