### PR TITLE
Add YAML support for application creation

### DIFF
--- a/src/controllers/devportalController.js
+++ b/src/controllers/devportalController.js
@@ -41,19 +41,48 @@ const monetizationService = require('../services/monetizationService');
 
 // ***** POST / DELETE / PUT Functions ***** (Only work in production)
 
+function parseApplicationDataFromRequest(req) {
+    const file = req.files?.application?.[0];
+    if (file?.buffer) {
+        let parsed;
+        try {
+            parsed = yaml.load(file.buffer.toString('utf8'));
+        } catch (e) {
+            throw new CustomError(400, "Bad Request", `Invalid application YAML: ${e.message}`);
+        }
+        if (!parsed || typeof parsed !== 'object') {
+            throw new CustomError(400, "Bad Request", "Invalid application YAML: expected an object");
+        }
+        const spec = parsed.spec || {};
+        const name = spec.displayName || parsed.metadata?.name;
+        if (!name) {
+            throw new CustomError(400, "Bad Request", "Missing required application field: name");
+        }
+        if (!spec.description) {
+            throw new CustomError(400, "Bad Request", "Missing required application field: description");
+        }
+        return {
+            name,
+            description: spec.description,
+            type: "WEB"
+        };
+    }
+    return req.body;
+}
+
 // ***** Save Application *****
 
 const saveApplication = async (req, res) => {
     try {
         const orgID = await adminDao.getOrgId(req.user[constants.ORG_IDENTIFIER]);
-        trackAppCreationStart({ orgId: orgID, appName: req.body.name, idpId: req.isAuthenticated() ? (req[constants.USER_ID] || req.user.sub) : undefined }, req);
-        const application = await adminDao.createApplication(orgID, req.user.sub, req.body);
-        trackAppCreationEnd({ orgId: orgID, appName: req.body.name, idpId: req.isAuthenticated() ? (req[constants.USER_ID] || req.user.sub) : undefined }, req);
+        const applicationData = parseApplicationDataFromRequest(req);
+        trackAppCreationStart({ orgId: orgID, appName: applicationData.name, idpId: req.isAuthenticated() ? (req[constants.USER_ID] || req.user.sub) : undefined }, req);
+        const application = await adminDao.createApplication(orgID, req.user.sub, applicationData);
+        trackAppCreationEnd({ orgId: orgID, appName: applicationData.name, idpId: req.isAuthenticated() ? (req[constants.USER_ID] || req.user.sub) : undefined }, req);
         return res.status(201).json(new ApplicationDTO(application.dataValues));
     } catch (error) {
         logger.error('Error occurred while creating the application', {
             orgId: req.user[constants.ORG_IDENTIFIER],
-            appName: req.body.name,
             error: error.message,
             stack: error.stack
         });
@@ -67,7 +96,8 @@ const updateApplication = async (req, res) => {
     try {
         const orgID = await adminDao.getOrgId(req.user[constants.ORG_IDENTIFIER]);
         const appID = req.params.applicationId;
-        const [updatedRows, updatedApp] = await adminDao.updateApplication(orgID, appID, req.user.sub, req.body);
+        const applicationData = parseApplicationDataFromRequest(req);
+        const [updatedRows, updatedApp] = await adminDao.updateApplication(orgID, appID, req.user.sub, applicationData);
         if (!updatedRows) {
             throw new Sequelize.EmptyResultError("No record found to update");
         }

--- a/src/routes/devportalRoute.js
+++ b/src/routes/devportalRoute.js
@@ -119,8 +119,12 @@ router.put('/organizations/:orgId/labels', enforceSecuirty(constants.SCOPES.ADMI
 router.get('/organizations/:orgId/labels', enforceSecuirty(constants.SCOPES.ADMIN), apiMetadataService.retrieveLabels);
 router.delete('/organizations/:orgId/labels', enforceSecuirty(constants.SCOPES.ADMIN), apiMetadataService.deleteLabels);
 
-router.post('/organizations/:orgId/applications', enforceSecuirty(constants.SCOPES.DEVELOPER), adminService.createDevPortalApplication);
-router.put('/organizations/:orgId/applications/:appId', enforceSecuirty(constants.SCOPES.DEVELOPER), adminService.updateDevPortalApplication);
+router.post('/organizations/:orgId/applications', enforceSecuirty(constants.SCOPES.DEVELOPER),
+    multipartHandler.fields([{name: 'application', maxCount: 1}]),
+    adminService.createDevPortalApplication);
+router.put('/organizations/:orgId/applications/:appId', enforceSecuirty(constants.SCOPES.DEVELOPER),
+    multipartHandler.fields([{name: 'application', maxCount: 1}]),
+    adminService.updateDevPortalApplication);
 router.get('/organizations/:orgId/applications/:appId', enforceSecuirty(constants.SCOPES.DEVELOPER), adminService.getDevPortalApplicationDetails);
 router.get('/organizations/:orgId/applications', enforceSecuirty(constants.SCOPES.DEVELOPER), adminService.getDevPortalApplications);
 router.delete('/organizations/:orgId/applications/:appId', enforceSecuirty(constants.SCOPES.DEVELOPER), adminService.deleteDevPortalApplication);
@@ -166,8 +170,12 @@ router.get('/organizations/:orgId/views/:name', enforceSecuirty(constants.SCOPES
 router.get('/organizations/:orgId/views', enforceSecuirty(constants.SCOPES.ADMIN), apiMetadataService.getAllViews);
 router.delete('/organizations/:orgId/views/:name', enforceSecuirty(constants.SCOPES.ADMIN), apiMetadataService.deleteView);
 
-router.post('/applications', enforceSecuirty(constants.SCOPES.DEVELOPER), devportalController.saveApplication);
-router.put('/applications/:applicationId', enforceSecuirty(constants.SCOPES.DEVELOPER), devportalController.updateApplication);
+router.post('/applications', enforceSecuirty(constants.SCOPES.DEVELOPER),
+    multipartHandler.fields([{name: 'application', maxCount: 1}]),
+    devportalController.saveApplication);
+router.put('/applications/:applicationId', enforceSecuirty(constants.SCOPES.DEVELOPER),
+    multipartHandler.fields([{name: 'application', maxCount: 1}]),
+    devportalController.updateApplication);
 router.delete('/applications/:applicationId', enforceSecuirty(constants.SCOPES.DEVELOPER), devportalController.deleteApplication);
 router.post('/applications/:applicationId/reset-throttle-policy', enforceSecuirty(constants.SCOPES.DEVELOPER), devportalController.resetThrottlingPolicy);
 router.post('/applications/:applicationId/api-keys/generate', enforceSecuirty(constants.SCOPES.DEVELOPER), devportalController.generateAPIKeys);

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -33,6 +33,7 @@ const config = require(process.cwd() + '/config.json');
 const controlPlaneUrl = config.controlPlane.url;
 const controlPlaneGwUrl = config.controlPlane.gwUrl;
 const { invokeApiRequest } = require('../utils/util');
+const yaml = require('js-yaml');
 const { Sequelize } = require("sequelize");
 const { trackGenerateCredentials, trackSubscribeApi, trackUnsubscribeApi } = require('../utils/telemetry');
 
@@ -742,7 +743,7 @@ const createDevPortalApplication = async (req, res) => {
         if (!orgId) {
             throw new CustomError(400, "Bad Request", "Missing required parameter: 'orgId'");
         }
-        const applicationData = req.body;
+        const applicationData = parseApplicationDataFromRequest(req);
         try {
             const application = await adminDao.createApplication(orgId, userID, applicationData);
             res.status(201).send(new ApplicationDTO(application.dataValues));
@@ -773,7 +774,7 @@ const updateDevPortalApplication = async (req, res) => {
     });
     try {
         const userId = req[constants.USER_ID]
-        const applicationData = req.body;
+        const applicationData = parseApplicationDataFromRequest(req);
         if (!orgId) {
             logger.warn('Missing required parameter: orgId');
             throw new CustomError(400, "Bad Request", "Missing required parameter: 'orgId'");
@@ -1905,6 +1906,35 @@ async function handleUnsubscribe(nonSharedToken, sharedToken, orgID, appID, apiR
         });
         throw error;
     }
+}
+
+function parseApplicationDataFromRequest(req) {
+    const file = req.files?.application?.[0];
+    if (file?.buffer) {
+        let parsed;
+        try {
+            parsed = yaml.load(file.buffer.toString('utf8'));
+        } catch (e) {
+            throw new CustomError(400, "Bad Request", `Invalid application YAML: ${e.message}`);
+        }
+        if (!parsed || typeof parsed !== 'object') {
+            throw new CustomError(400, "Bad Request", "Invalid application YAML: expected an object");
+        }
+        const spec = parsed.spec || {};
+        const name = spec.displayName || parsed.metadata?.name;
+        if (!name) {
+            throw new CustomError(400, "Bad Request", "Missing application name");
+        }
+        if (!spec.description) {
+            throw new CustomError(400, "Bad Request", "Missing required application field: description");
+        }
+        return {
+            name,
+            description: spec.description,
+            type: "WEB"
+        };
+    }
+    return req.body;
 }
 
 module.exports = {


### PR DESCRIPTION
## Purpose
Providing the ability to create the devportal applications through a yaml structure
Fixes https://github.com/wso2-enterprise/apim-saas/issues/2376

## Approach
Update the /application POST and PUT endpoints to accept yaml files with the following format:

```
apiVersion: devportal.wso2.com/v1alpha1
kind: Application
metadata:
  name: payments-app
spec:
  displayName: PaymentsApp
  description: Client app for payment APIs
  // any other properties can be supported later
```

## Samples
N/A
