### PR TITLE
feat: enhance API flow source URL resolution and update documentation links in workflow markdown

### DIFF
--- a/src/controllers/apiFlowsController.js
+++ b/src/controllers/apiFlowsController.js
@@ -44,6 +44,26 @@ const extractSourceDescriptions = (flow) => {
     }
 };
 
+const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const buildSpecUrlPattern = (orgName, viewName) =>
+    new RegExp(
+        `^(?:https?://[^/]+)?/${escapeRegex(orgName)}/views/${escapeRegex(viewName)}/(api|mcp)/([^/]+)/docs/specification\\.(json|graphql|xml)$`
+    );
+
+const resolveSourceUrls = async (sources, orgName, viewName, orgID) => {
+    const pattern = buildSpecUrlPattern(orgName, viewName);
+    return Promise.all(sources.map(async (source) => {
+        if (!source.url) return source;
+        const match = source.url.match(pattern);
+        if (!match) return source;
+        const [, apiType, apiHandle] = match;
+        const apiId = await apiMetadataDao.getAPIId(orgID, apiHandle);
+        if (!apiId) return source;
+        return { ...source, url: `/${orgName}/views/${viewName}/${apiType}/${apiHandle}.md`, isDevportalApi: true };
+    }));
+};
+
 
 const loadAPIFlows = async (req, res) => {
     const { orgName, viewName } = req.params;
@@ -280,7 +300,8 @@ const getWorkflowDetailMd = async (req, res) => {
         if (apiFlow.CONTENT_TYPE === 'ARAZZO') {
             try {
                 const arazoJson = JSON.parse(workflowContent);
-                const sources = extractSourceDescriptions(apiFlow);
+                const rawSources = extractSourceDescriptions(apiFlow);
+                const sources = await resolveSourceUrls(rawSources, orgName, viewName, orgID);
                 markdownContent = generateWorkflowMarkdown(arazoJson, apiFlow, orgName, viewName, sources);
             } catch (e) {
                 logger.warn('Could not parse Arazzo JSON, using raw content', { handle, error: e.message });

--- a/src/defaultContent/pages/api-flows/workflow-markdown.hbs
+++ b/src/defaultContent/pages/api-flows/workflow-markdown.hbs
@@ -8,10 +8,10 @@
 ## Sources
 
 {{#each sources}}
-- **{{this.name}}**{{#if this.url}} — [OpenAPI Spec]({{this.url}}){{/if}}
+- **{{this.name}}**{{#if this.url}} — {{#if this.isDevportalApi}}[API Documentation]({{this.url}}){{else}}[OpenAPI Spec]({{this.url}}){{/if}}{{/if}}
 {{/each}}
 
-> Refer to each source's OpenAPI spec for base URL, endpoints, and security schemes. If an API with a matching name is listed in the [API catalogue]({{baseUrl}}/apis.md), you can use that page for additional details.
+> Refer to each source for base URLs, endpoints, security schemes, and any additional documentation needed to execute this workflow.
 
 ## Authentication
 

--- a/src/defaultContent/pages/api-flows/workflow-markdown.hbs
+++ b/src/defaultContent/pages/api-flows/workflow-markdown.hbs
@@ -15,10 +15,15 @@
 
 ## Authentication
 
-Before executing this workflow, read the `securitySchemes` section of each source's OpenAPI spec to determine the authentication method required:
+To determine the authentication method required for each source:
+
+- **API Documentation sources**: Check the source's documentation page for an **API Key** section (if API key auth is required) or an **OAuth2** section (if OAuth2 is required).
+- **OpenAPI Spec sources**: Read the `securitySchemes` section of the spec to determine the authentication method.
+
+Once the method is identified, follow the appropriate steps below:
 
 - **OAuth2**: Request the user's `client_id` and `client_secret`, then obtain an access token from the `tokenUrl` specified in the spec using the client credentials grant (`grant_type=client_credentials`). Use the token as a Bearer token in the `Authorization` header.
-- **API Key**: Each source may require its own API key. Request the API key for each source separately and pass it in the header or query parameter as specified in that source's spec.
+- **API Key**: Request the API key for each source separately and pass it in the header or query parameter as specified in that source's documentation or spec.
 
 Never hardcode or log credentials. Store them only for the duration of the workflow execution.
 


### PR DESCRIPTION


```
# Specialist Treatment Booking Workflow

**Status:** PUBLISHED

**Description:** Automates the end-to-end journey of booking a specialist medical appointment — from diagnosing the right treatment for a clinical condition, to finding an available provider near the patient, confirming a slot, estimating out-of-pocket costs, and delivering a booking confirmation via email or SMS

## Sources

- **provider-api-v1.0** — [API Documentation](/aiorg/views/default/api/provider-api-v1.0.md)
- **treatment-api-v1.0** — [API Documentation](/aiorg/views/default/api/treatment-api-v1.0.md)
- **notification-api-v1.0** — [API Documentation](/aiorg/views/default/api/notification-api-v1.0.md)
- **pricing-api-v1.0** — [API Documentation](/aiorg/views/default/api/pricing-api-v1.0.md)
- **bookings-api-v1.0** — [API Documentation](/aiorg/views/default/api/bookings-api-v1.0.md)
- **availability-api-v1.0** — [API Documentation](/aiorg/views/default/api/availability-api-v1.0.md)
- **patients-api-v1.0** — [API Documentation](/aiorg/views/default/api/patients-api-v1.0.md)
- **payments-api** — [OpenAPI Spec](https://console.openapi.com/oas/en/bollettini.openapi.json)

> Refer to each source for base URLs, endpoints, security schemes, and any additional documentation needed to execute this workflow.

## Authentication

Before executing this workflow, read the `securitySchemes` section of each source's OpenAPI spec to determine the authentication method required:

- **OAuth2**: Request the user's `client_id` and `client_secret`, then obtain an access token from the `tokenUrl` specified in the spec using the client credentials grant (`grant_type=client_credentials`). Use the token as a Bearer token in the `Authorization` header.
- **API Key**: Each source may require its own API key. Request the API key for each source separately and pass it in the header or query parameter as specified in that source's spec.

Never hardcode or log credentials. Store them only for the duration of the workflow execution.

## API Flow Specification

```