### PR TITLE
feat: add middleware to redirect unrecognized root-level paths to home page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -565,6 +565,10 @@ app.use(constants.ROUTE.TECHNICAL_SCRIPTS, express.static(path.join(require.main
 //backend routes
 app.use(constants.ROUTE.DEV_PORTAL, devportalRoute);
 
+app.get('/robots.txt', (req, res) => {
+    res.redirect('/');
+});
+
 if (config.mode === constants.DEV_MODE) {
     app.use(constants.ROUTE.STYLES, express.static(path.join(process.cwd(), filePrefix + 'styles')));
     app.use(constants.ROUTE.IMAGES, express.static(path.join(process.cwd(), filePrefix + 'images')));

--- a/src/app.js
+++ b/src/app.js
@@ -562,12 +562,19 @@ passport.deserializeUser(async (sessionData, done) => {
 app.use(constants.ROUTE.TECHNICAL_STYLES, express.static(path.join(require.main.filename, '../styles')));
 app.use(constants.ROUTE.TECHNICAL_SCRIPTS, express.static(path.join(require.main.filename, '../scripts')));
 
+// Redirect unrecognised root-level paths (e.g. /robots.txt, /sitemap.xml) before
+// the /:orgName route can treat them as org IDs.
+app.use((req, res, next) => {
+    const segments = req.path.split('/').filter(Boolean);
+    if (segments.length === 1 && segments[0].includes('.')) {
+        return res.redirect('/');
+    }
+    next();
+});
+
 //backend routes
 app.use(constants.ROUTE.DEV_PORTAL, devportalRoute);
 
-app.get('/robots.txt', (req, res) => {
-    res.redirect('/');
-});
 
 if (config.mode === constants.DEV_MODE) {
     app.use(constants.ROUTE.STYLES, express.static(path.join(process.cwd(), filePrefix + 'styles')));
@@ -587,6 +594,10 @@ if (config.mode === constants.DEV_MODE) {
     app.use(constants.ROUTE.DEFAULT, customContent);
 }
 
+
+app.use((req, res) => {
+    res.redirect('/');
+});
 
 app.use( (err, req, res, next) => {
     Handlebars.registerPartial('header', '');


### PR DESCRIPTION
Claude.ai is currently restricted from fetching Devportal web content because it is unable to resolve the robots.txt file. However, it is able to access the AI workspace, which does not include a robots.txt file and instead redirects to the homepage when /robots.txt is requested.


claude reccomendation

```
My recommendation: serve a proper robots.txt at the root rather than redirecting.                                                 
                                          
  Here's why:                                                                                                                       
  - robots.txt and llms.txt serve different purposes — bots expect a valid robots.txt with crawl directives, not a redirect.        
  Redirecting would confuse standard crawlers.                                                                              
  - Redirecting to baseurl is even less useful — bots don't follow redirects from robots.txt and expect a text file.                
  - The right fix is to add a route that returns a valid robots.txt body and optionally includes a pointer to the llms.txt URL
  (e.g., as a comment or Sitemap: line).                                                                                            
                                              
  Want me to add a /robots.txt route in app.js that serves a standard response like:                                                
                                                                                                                                    
  User-agent: *                                                                                                                     
  Allow: /                                                                                                                          
                                                                                                                                    
  # AI agent guidance: /{orgName}/views/{viewName}/llms.txt
```