### PR TITLE
[Feature] Add mcp registry support

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -36,6 +36,7 @@ const applicationContent = require('./routes/applicationsContentRoute');
 const sdkJobService = require('./services/sdkJobService');
 const customContent = require('./routes/customPageRoute');
 const subscriptionsContent = require('./routes/subscriptionsContentRoute');
+const mcpRegistryRoute = require('./routes/mcpRegistryRoute');
 const config = require(process.cwd() + '/config.json');
 const Handlebars = require('handlebars');
 const constants = require("./utils/constants");
@@ -273,6 +274,12 @@ Handlebars.registerHelper('and', function () {
     const args = Array.prototype.slice.call(arguments);
     const lastArg = args.pop();
     return args.every(Boolean) ? lastArg.fn(this) : lastArg.inverse(this);
+});
+
+Handlebars.registerHelper('or', function (...args) {
+    // Last arg is the Handlebars options hash; find first truthy value before it
+    const vals = args.slice(0, -1);
+    return vals.find(v => v) || vals[vals.length - 1];
 });
 
 Handlebars.registerHelper('getValue', function (obj, key) {
@@ -581,6 +588,8 @@ app.use((req, res, next) => {
 //backend routes
 app.use(constants.ROUTE.DEV_PORTAL, devportalRoute);
 
+// MCP Server Registry (OpenAPI v0.1)
+app.use('/registry/:orgHandle', mcpRegistryRoute);
 
 if (config.mode === constants.DEV_MODE) {
     app.use(constants.ROUTE.STYLES, express.static(path.join(process.cwd(), filePrefix + 'styles')));

--- a/src/controllers/apiContentController.js
+++ b/src/controllers/apiContentController.js
@@ -280,7 +280,8 @@ const loadAPIContent = async (req, res) => {
             
             let apiDetail = null;
             //check whether user has access to the API via control plane
-            if (config.controlPlane?.enabled !== false && !isFederatedAPI) {
+            const isMCPFromRegistry = metaData.apiInfo?.apiType === constants.API_TYPE.MCP && !metaData.apiReferenceID;
+            if (config.controlPlane?.enabled !== false && !isFederatedAPI && !isMCPFromRegistry) {
                 try {
                     apiDetail = await util.invokeApiRequest(req, 'GET', controlPlaneUrl + `/apis/${metaData.apiReferenceID}`, null, null);
                     if (!apiDetail) {
@@ -339,7 +340,8 @@ const loadAPIContent = async (req, res) => {
                       metaData.apiInfo &&
                       metaData.apiInfo.apiType !== constants.API_TYPE.GRAPHQL &&
                       metaData.apiInfo.apiType !== constants.API_TYPE.WS &&
-                      metaData.apiInfo.apiType !== constants.API_TYPE.WEBSUB
+                      metaData.apiInfo.apiType !== constants.API_TYPE.WEBSUB &&
+                      metaData.apiInfo.apiType !== constants.API_TYPE.MCP
                     ) {
                         apiDefinition = "";
                         apiDefinition = await apiDao.getAPIFile(constants.FILE_NAME.API_DEFINITION_FILE_NAME, constants.DOC_TYPES.API_DEFINITION, orgID, apiID);
@@ -378,15 +380,21 @@ const loadAPIContent = async (req, res) => {
                         }
                     }
                     if (constants.API_TYPE.MCP === metaData.apiInfo?.apiType) {
+                        const mcpRemotes = metaData.apiInfo?.remotes || [];
+                        const mcpProductionURL = mcpRemotes.length > 0 ? mcpRemotes[0].url : (metaData.endPoints?.productionURL || '');
+                        apiDetails = {};
+                        apiDetails['serverDetails'] = mcpProductionURL ? { productionURL: mcpProductionURL, sandboxURL: '' } : '';
                         try {
                             let rawSchema = await apiDao.getAPIFile(
-                                constants.FILE_NAME.SCHEMA_DEFINITION_FILE_NAME,
+                                'schema.json',
                                 constants.DOC_TYPES.SCHEMA_DEFINITION,
                                 orgID,
                                 apiID
                             );
-                            const schemaString = rawSchema.API_FILE.toString(constants.CHARSET_UTF8);
-                            schemaDefinition = JSON.parse(schemaString);
+                            if (rawSchema) {
+                                const schemaString = rawSchema.API_FILE.toString(constants.CHARSET_UTF8);
+                                schemaDefinition = JSON.parse(schemaString);
+                            }
                         } catch (err) {
                             logger.error("Failed to load or parse schema definition", {
                                 orgID: orgID,
@@ -394,7 +402,6 @@ const loadAPIContent = async (req, res) => {
                                 error: err.message, 
                                 stack: err.stack
                             });
-                            throw err;
                         }
                     }
                 }
@@ -517,8 +524,9 @@ const getAPIDefinition = async (orgName, viewName, apiHandle) => {
         metaData = JSON.parse(data);
         templateContent.apiType = metaData.apiInfo.apiType;
             let apiDefinition;
-            const apiType = metaData.apiInfo.apiType;
-            if (apiType === constants.API_TYPE.GRAPHQL) {
+            if (metaData.apiInfo.apiType === constants.API_TYPE.MCP) {
+                templateContent.swagger = null;
+            } else if (metaData.apiInfo.apiType === constants.API_TYPE.GRAPHQL) {
                 apiDefinition = await apiDao.getAPIFile(constants.FILE_NAME.API_DEFINITION_GRAPHQL, constants.DOC_TYPES.API_DEFINITION, orgID, apiID);
                 templateContent.graphql = apiDefinition.API_FILE.toString(constants.CHARSET_UTF8);
             } else if (apiType === constants.API_TYPE.MCP) {
@@ -646,8 +654,9 @@ const loadDocument = async (req, res) => {
         
         const gatewayVendor = apiMetadata?.apiInfo?.gatewayVendor || 'wso2';
         const isFederatedAPI = constants.FEDERATED_GATEWAY_VENDORS.includes(gatewayVendor);
+        const isMCPFromRegistry = apiMetadata?.apiInfo?.apiType === constants.API_TYPE.MCP && !apiMetadata?.apiReferenceID;
         //check whether user has access to the API via control plane
-        if (config.controlPlane?.enabled !== false && !isFederatedAPI) {
+        if (config.controlPlane?.enabled !== false && !isFederatedAPI && !isMCPFromRegistry) {
             try {
                 let apiName = "";
                 if (apiMetadata && typeof apiMetadata.apiHandle === "string" && apiMetadata.apiHandle.includes("-v")) {
@@ -688,7 +697,11 @@ const loadDocument = async (req, res) => {
         //load API definition
         if (req.originalUrl.includes(constants.FILE_NAME.API_SPECIFICATION_PATH)) {
 
-            if (definitionResponse.apiType !== constants.API_TYPE.WS && definitionResponse.apiType !== constants.API_TYPE.GRAPHQL && definitionResponse.apiType !== constants.API_TYPE.WEBSUB) {
+            if (isMCPFromRegistry) {
+                const remotes = apiMetadata?.apiInfo?.remotes || [];
+                const serverUrl = remotes.length > 0 ? remotes[0].url : '';
+                templateContent.swagger = JSON.stringify({ servers: [{ url: serverUrl }] });
+            } else if (definitionResponse.apiType !== constants.API_TYPE.WS && definitionResponse.apiType !== constants.API_TYPE.GRAPHQL && definitionResponse.apiType !== constants.API_TYPE.WEBSUB) {
                 let modifiedSwagger = replaceEndpointParams(JSON.parse(definitionResponse.swagger), apiMetadata.endPoints.productionURL, apiMetadata.endPoints.sandboxURL);
                 if (config.controlPlane?.enabled !== false) {
                     try {
@@ -785,9 +798,14 @@ const loadDocument = async (req, res) => {
                 const orgID = await adminDao.getOrgId(orgName);
                 const apiID = await apiDao.getAPIId(orgID, apiHandle);
                 const viewName = req.params.viewName;
-                const docNames = await apiMetadataService.getAPIDocTypes(orgID, apiID);
+                let docNames = await apiMetadataService.getAPIDocTypes(orgID, apiID);
                 const apiMetadata = await apiDao.getAPIMetadata(orgID, apiID);
                 let apiType = apiMetadata[0].dataValues.API_TYPE;
+                const referenceID = apiMetadata[0].dataValues.REFERENCE_ID;
+                // Registry MCPs have no stored doc types — inject Specification entry so sidebar renders
+                if (apiType === constants.API_TYPE.MCP && !referenceID && docNames.length === 0) {
+                    docNames = [{ type: constants.DOC_TYPES.DOCS.API_DEFINITION }];
+                }
                 templateContent.baseUrl = '/' + orgName + constants.ROUTE.VIEWS_PATH + viewName;
                 templateContent.baseDocUrl = baseDocUrl;                
                 templateContent.docTypes = docNames;

--- a/src/dao/apiMetadata.js
+++ b/src/dao/apiMetadata.js
@@ -84,7 +84,7 @@ const createAPILabelMapping = async (orgID, apiID, labels, t) => {
                 ORG_ID: orgID
             });
         });
-        const labelResponse = await APILabels.bulkCreate(labelList, { transaction: t });
+        const labelResponse = await APILabels.bulkCreate(labelList, { transaction: t, ignoreDuplicates: true });
         return labelResponse;
     } catch (error) {
         if (error instanceof Sequelize.UniqueConstraintError) {

--- a/src/defaultContent/pages/mcp-landing/partials/mcp-default.hbs
+++ b/src/defaultContent/pages/mcp-landing/partials/mcp-default.hbs
@@ -31,7 +31,7 @@
           <div class="defaultapi-endpoint-row col-12 col-xl-9">
             <div class="defaultapi-endpoint-content">
               <div class="defaultapi-endpoint-url-container d-flex">
-                <pre id="token_mcp_prod_url" class="defaultapi-endpoint-url token-text mb-0">{{resources.serverDetails.productionURL}}/mcp</pre>                
+                <pre id="token_mcp_prod_url" class="defaultapi-endpoint-url token-text mb-0">{{resources.serverDetails.productionURL}}</pre>                
                   <a class="copy-button" aria-label="Copy token" type="button" onclick="copyToken('mcp_prod_url')">
                     <i class="bi bi-copy"></i>
                   </a>
@@ -43,9 +43,11 @@
     </div>
       <div class="defaultapi-section">
       <div class="row">
+        <div class="col-12 col-lg-7 mb-4">
+        {{#if schemaDefinition.tools.length}}
         <div class="container-header mb-4">Tools</div>
-        <div class="defaultapi-resources col-12 col-lg-6 mb-4" style="margin-right: 30px;">
-          {{#each schemaDefinition}}
+        <div class="defaultapi-resources mb-4">
+          {{#each schemaDefinition.tools}}
             <div class="accordion-set">
               <button
                 class="accordion-header"
@@ -67,6 +69,63 @@
             </div>
           {{/each}}
         </div>
+        {{/if}}
+        {{#if schemaDefinition.resources.length}}
+        <div class="container-header mb-4">Resources</div>
+        <div class="defaultapi-resources mb-4">
+          {{#each schemaDefinition.resources}}
+            <div class="accordion-set">
+              <button
+                class="accordion-header"
+                onclick="this.classList.toggle('open')"
+              >
+                <span>{{this.name}}</span>
+                <i class="chevron-icon bi bi-chevron-down"></i>
+              </button>
+              <div class="accordion-body">
+                {{#if this.description}}
+                  <p class="accordion-summary">{{this.description}}</p>
+                {{else}}
+                  <p class="accordion-summary">No summary available.</p>
+                {{/if}}
+                {{#if this.uri}}
+                  <p class="accordion-summary"><strong>URI:</strong> {{this.uri}}</p>
+                {{/if}}
+                {{#if this.mimeType}}
+                  <p class="accordion-summary"><strong>MIME Type:</strong> {{this.mimeType}}</p>
+                {{/if}}
+              </div>
+            </div>
+          {{/each}}
+        </div>
+        {{/if}}
+        {{#if schemaDefinition.prompts.length}}
+        <div class="container-header mb-4">Prompts</div>
+        <div class="defaultapi-resources mb-4">
+          {{#each schemaDefinition.prompts}}
+            <div class="accordion-set">
+              <button
+                class="accordion-header"
+                onclick="this.classList.toggle('open')"
+              >
+                <span>{{this.name}}</span>
+                <i class="chevron-icon bi bi-chevron-down"></i>
+              </button>
+              <div class="accordion-body">
+                {{#if this.description}}
+                  <p class="accordion-summary">{{this.description}}</p>
+                {{else}}
+                  <p class="accordion-summary">No summary available.</p>
+                {{/if}}
+                {{#if this.arguments}}
+                    <pre class="json-block"><code>    {{jsonBeautify this.arguments}}</code></pre>
+                {{/if}}
+              </div>
+            </div>
+          {{/each}}
+        </div>
+        {{/if}}
+        </div>
         <div class="defaultapi-resources-mcp col-12 col-lg-5 mb-4">
           <div class="mcp-json-block-header">MCP Server Configuration</div>
         <div class="server-config-container" style="position: relative;">
@@ -75,7 +134,7 @@
 {
   <span class="schema-title">"servers"</span>: {
     <span class="schema-title">"{{apiMetadata.apiInfo.apiName}}"</span>: {
-      <span class="schema-title">"url"</span>: <span class="schema-content">"{{resources.serverDetails.productionURL}}/mcp"</span>,
+      <span class="schema-title">"url"</span>: <span class="schema-content">"{{resources.serverDetails.productionURL}}"</span>,
       <span class="schema-title">"type"</span>: <span class="schema-content">"http"</span>,
       <span class="schema-title">"headers"</span>: {
         <span class="schema-title">"Authorization"</span>: <span class="schema-content">"Bearer ${token}</span>"

--- a/src/defaultContent/pages/mcp-landing/partials/mcp-detail-banner.hbs
+++ b/src/defaultContent/pages/mcp-landing/partials/mcp-detail-banner.hbs
@@ -4,7 +4,7 @@
       <div class="col-12 col-md-7">
         <div class="api-title">
           <span class="badge api-badge-custom1">{{apiMetadata.apiInfo.apiCategory}}</span>
-          <h4>{{apiMetadata.apiInfo.apiName}}</h4>
+          <h4>{{or apiMetadata.apiInfo.apiTitle apiMetadata.apiInfo.apiName}}</h4>
           <p class="api-version"> {{apiMetadata.apiInfo.apiVersion}}</p>
         </div>
         <p class="api-description">{{apiMetadata.apiInfo.apiDescription}}</p>
@@ -14,10 +14,18 @@
           {{/apiMetadata.apiInfo.tags}}
         </div>
         <div class="api-details-btn">
+          {{#if apiMetadata.apiReferenceID}}
           <a type="button" class="common-btn-primary" href="#subscriptionPlans">Subscribe</a>
+          {{else}}
+          {{#unless (eq apiMetadata.apiInfo.apiType "MCP")}}
+          <a type="button" class="common-btn-primary" href="#subscriptionPlans">Subscribe</a>
+          {{/unless}}
+          {{/if}}
           {{#in apiMetadata.apiInfo.apiType values="REST,WS,GraphQL,MCP,WEBSUB"}}
+          {{#if apiMetadata.apiReferenceID}}
           <a type="button" class="common-btn-outlined"
             href="{{baseUrl}}/mcp/{{apiMetadata.apiHandle}}/docs/specification">Documentation</a>
+          {{/if}}
           {{else}}
           <a type="button" class="common-btn-outlined" href="{{{schemaUrl}}}" download>Download</a>
           {{/in}}
@@ -27,7 +35,7 @@
         {{#if apiMetadata.apiInfo.apiImageMetadata.api-icon}}
         <img class="img-thumbnail api-image" src="{{apiMetadata.apiInfo.apiImageMetadata.api-icon}}" alt="API Image" />
         {{else}}
-        <div class="img-thumbnail api-image image-icon d-flex justify-content-center align-items-center">{{firstTwoLetters apiMetadata.apiInfo.apiName}}</div>
+        <div class="img-thumbnail api-image image-icon d-flex justify-content-center align-items-center">{{firstTwoLetters (or apiMetadata.apiInfo.apiTitle apiMetadata.apiInfo.apiName)}}</div>
         {{/if}}
       </div>
     </div>

--- a/src/defaultContent/pages/mcp/partials/mcp-listing.hbs
+++ b/src/defaultContent/pages/mcp/partials/mcp-listing.hbs
@@ -66,10 +66,10 @@
                {{#if apiInfo.apiImageMetadata.api-icon}}
                   <img src="{{apiInfo.apiImageMetadata.api-icon}}" class="api-card-img" alt="..." />
                 {{else}}
-                  <div class="image-icon">{{firstTwoLetters apiInfo.apiName}}</div>
+                  <div class="image-icon">{{firstTwoLetters (or apiInfo.apiTitle apiInfo.apiName)}}</div>
                 {{/if}}
             <div class="flex-grow-1">
-              <h5 class="api-card-title mb-0">{{apiInfo.apiName}}</h5>
+              <h5 class="api-card-title mb-0">{{or apiInfo.apiTitle apiInfo.apiName}}</h5>
               <div class="d-flex align-items-center gap-2">
                 <p class="mb-0 mt-1" style="font-size: 16px;">{{apiInfo.apiVersion}}</p>
                   <div class="type-badge badge-custom2" style="display: flex; flex-direction: row; align-items: center;">

--- a/src/dto/apiDTO.js
+++ b/src/dto/apiDTO.js
@@ -52,6 +52,8 @@ class APIDTO {
 class APIInfo {
     constructor(apiInfo) {
         this.apiName = apiInfo.API_NAME;
+        this.apiTitle = apiInfo.METADATA_SEARCH?.apiInfo?.apiTitle || null;
+        this.remotes = apiInfo.METADATA_SEARCH?.apiInfo?.remotes || [];
         this.apiVersion = apiInfo.API_VERSION;
         this.apiDescription = apiInfo.API_DESCRIPTION;
         this.apiType = apiInfo.API_TYPE;

--- a/src/dto/mcpServer.js
+++ b/src/dto/mcpServer.js
@@ -63,7 +63,7 @@ class ServerResponseDTO {
                 updatedAt: registryMeta.updatedAt || undefined,
                 isLatest: true
             },
-            ...(schema ? { 'io.choreo/mcp-capabilities': choreoCapabilities } : {})
+            ...(schema ? { 'io.api-platform/mcp-capabilities': choreoCapabilities } : {})
         };
     }
 }

--- a/src/dto/mcpServer.js
+++ b/src/dto/mcpServer.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const REGISTRY_META_KEY = 'io.modelcontextprotocol.registry/official';
+
+const STATUS_MAP = {
+    PUBLISHED: 'active',
+    DEPRECATED: 'deprecated',
+    DELETED: 'deleted'
+};
+
+/**
+ * Maps a DP_API_METADATA row (+ optional parsed schema) to the MCP registry spec response shape.
+ *
+ * @param {object} row        - Sequelize APIMetadata instance or plain object
+ * @param {object} [schema]   - Parsed schema object { tools, resources, prompts } from DP_API_CONTENT
+ */
+class ServerResponseDTO {
+    constructor(row, schema) {
+        const source = typeof row?.get === 'function' ? row.get({ plain: true }) : row;
+
+        const storedRemotes = source.METADATA_SEARCH?.apiInfo?.remotes;
+        const remotes = Array.isArray(storedRemotes) && storedRemotes.length > 0
+            ? storedRemotes
+            : (source.PRODUCTION_URL ? [{ type: 'streamable-http', url: source.PRODUCTION_URL }] : []);
+
+        this.server = {
+            $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+            name: source.API_NAME,
+            title: source.METADATA_SEARCH?.apiInfo?.apiTitle || undefined,
+            version: source.API_VERSION,
+            description: source.API_DESCRIPTION,
+            remotes
+        };
+
+        const choreoCapabilities = {};
+        if (schema) {
+            choreoCapabilities.tools = schema.tools || [];
+            choreoCapabilities.resources = schema.resources || [];
+            choreoCapabilities.prompts = schema.prompts || [];
+        }
+
+        const registryMeta = source.METADATA_SEARCH?.apiInfo || {};
+        this._meta = {
+            [REGISTRY_META_KEY]: {
+                status: STATUS_MAP[source.STATUS] || source.STATUS,
+                publishedAt: registryMeta.publishedAt || undefined,
+                updatedAt: registryMeta.updatedAt || undefined,
+                isLatest: true
+            },
+            ...(schema ? { 'io.choreo/mcp-capabilities': choreoCapabilities } : {})
+        };
+    }
+}
+
+module.exports = ServerResponseDTO;

--- a/src/models/apiMetadata.js
+++ b/src/models/apiMetadata.js
@@ -51,7 +51,7 @@ const APIMetadata = sequelize.define('DP_API_METADATA', {
   },
   API_TYPE: {
     type: DataTypes.ENUM,
-    values: ['REST', 'WS', 'GRAPHQL', 'SOAP', 'WEBSUB'],
+    values: ['REST', 'WS', 'GRAPHQL', 'SOAP', 'WEBSUB', 'MCP'],
     allowNull: false
   },
   VISIBILITY: {

--- a/src/routes/mcpRegistryRoute.js
+++ b/src/routes/mcpRegistryRoute.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+const mcpRegistryService = require('../services/mcpRegistryService');
+const { enforceSecuirty } = require('../middlewares/ensureAuthenticated');
+const constants = require('../utils/constants');
+
+// Discovery endpoints (public)
+router.get('/v0.1/servers', mcpRegistryService.listServers);
+router.get('/v0.1/servers/:serverName/versions', mcpRegistryService.listVersions);
+router.get('/v0.1/servers/:serverName/versions/:version', mcpRegistryService.getVersion);
+
+// Publishing endpoints (API key or session auth — same as all other devportal write routes)
+router.post('/v0.1/publish', enforceSecuirty(constants.SCOPES.DEVELOPER), mcpRegistryService.publishServer);
+router.put('/v0.1/servers/:serverName/versions/:version', enforceSecuirty(constants.SCOPES.DEVELOPER), mcpRegistryService.updateVersion);
+router.delete('/v0.1/servers/:serverName/versions/:version', enforceSecuirty(constants.SCOPES.DEVELOPER), mcpRegistryService.deleteVersion);
+router.patch('/v0.1/servers/:serverName/versions/:version/status', enforceSecuirty(constants.SCOPES.DEVELOPER), mcpRegistryService.updateVersionStatus);
+router.patch('/v0.1/servers/:serverName/status', enforceSecuirty(constants.SCOPES.DEVELOPER), mcpRegistryService.updateAllVersionsStatus);
+
+module.exports = router;

--- a/src/services/mcpRegistryService.js
+++ b/src/services/mcpRegistryService.js
@@ -167,6 +167,18 @@ const listServers = async (req, res) => {
         const limit = normalizeLimit(req.query.limit);
         const search = req.query.search;
 
+        let currentOffset = 0;
+        if (req.query.cursor) {
+            try {
+                const decoded = JSON.parse(Buffer.from(req.query.cursor, 'base64url').toString('utf-8'));
+                if (typeof decoded.offset === 'number' && decoded.offset >= 0) {
+                    currentOffset = decoded.offset;
+                }
+            } catch {
+                return sendError(res, 400, 'Invalid cursor');
+            }
+        }
+
         const where = { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP };
         if (!includeDeleted) {
             where.STATUS = { [Op.ne]: 'DELETED' };
@@ -178,14 +190,15 @@ const listServers = async (req, res) => {
         const rows = await APIMetadata.findAll({
             where,
             order: [[sequelize.literal("(\"METADATA_SEARCH\"->'apiInfo'->>'publishedAt')"), 'DESC NULLS LAST']],
-            limit: limit + 1
+            limit: limit + 1,
+            offset: currentOffset
         });
 
         const hasMore = rows.length > limit;
         const pageRows = hasMore ? rows.slice(0, limit) : rows;
         const metadata = { count: pageRows.length };
         if (hasMore) {
-            metadata.nextCursor = Buffer.from(JSON.stringify({ offset: limit })).toString('base64url');
+            metadata.nextCursor = Buffer.from(JSON.stringify({ offset: currentOffset + limit })).toString('base64url');
         }
 
         return res.status(200).json({
@@ -275,16 +288,18 @@ const publishServer = async (req, res) => {
         const orgId = await resolveOrgId(orgHandle);
         const { name, version, title, description, _meta } = detail;
         const remotes = detail.remotes || [];
-        const choreoMeta = (_meta && _meta['io.choreo/mcp-capabilities']) || {};
-        const tools = choreoMeta.tools || [];
-        const resources = choreoMeta.resources || [];
-        const prompts = choreoMeta.prompts || [];
+        const choreoMeta = _meta && _meta['io.api-platform/mcp-capabilities'];
+        const tools = choreoMeta?.tools || [];
+        const resources = choreoMeta?.resources || [];
+        const prompts = choreoMeta?.prompts || [];
         const now = new Date().toISOString();
-        const schemaContent = JSON.stringify({ tools, resources, prompts });
-        const schemaBuffer = Buffer.from(schemaContent, 'utf-8');
+        const schemaBuffer = choreoMeta
+            ? Buffer.from(JSON.stringify({ tools, resources, prompts }), 'utf-8')
+            : null;
 
         let row;
         let created = false;
+        let existingApiId = null;
 
         await sequelize.transaction(async (t) => {
             const existing = await APIMetadata.findOne({
@@ -293,28 +308,40 @@ const publishServer = async (req, res) => {
             });
 
             if (existing) {
+                existingApiId = existing.API_ID;
                 const existingPublishedAt = existing.METADATA_SEARCH?.apiInfo?.publishedAt || now;
                 const apiMetadataPayload = buildApiMetadataPayload(name, version, description, remotes, title, existingPublishedAt, now);
                 await apiDao.updateAPIMetadata(orgId, existing.API_ID, apiMetadataPayload, t);
                 await apiDao.createAPILabelMapping(orgId, existing.API_ID, ['default'], t);
-                await apiDao.updateOrCreateAPIFiles(
-                    [{ content: schemaBuffer, fileName: SCHEMA_FILE_NAME, type: constants.DOC_TYPES.SCHEMA_DEFINITION }],
-                    existing.API_ID, orgId, t
-                );
+                if (schemaBuffer) {
+                    await apiDao.updateOrCreateAPIFiles(
+                        [{ content: schemaBuffer, fileName: SCHEMA_FILE_NAME, type: constants.DOC_TYPES.SCHEMA_DEFINITION }],
+                        existing.API_ID, orgId, t
+                    );
+                }
                 row = await APIMetadata.findOne({ where: { API_ID: existing.API_ID }, transaction: t });
             } else {
                 const apiMetadataPayload = buildApiMetadataPayload(name, version, description, remotes, title, now, now);
                 const created_row = await apiDao.createAPIMetadata(orgId, apiMetadataPayload, t);
                 const apiId = created_row.dataValues.API_ID;
                 await apiDao.createAPILabelMapping(orgId, apiId, ['default'], t);
-                await apiDao.storeAPIFile(schemaBuffer, SCHEMA_FILE_NAME, apiId, constants.DOC_TYPES.SCHEMA_DEFINITION, t);
+                const newSchemaBuffer = schemaBuffer || Buffer.from(JSON.stringify({ tools: [], resources: [], prompts: [] }), 'utf-8');
+                await apiDao.storeAPIFile(newSchemaBuffer, SCHEMA_FILE_NAME, apiId, constants.DOC_TYPES.SCHEMA_DEFINITION, t);
                 row = await APIMetadata.findOne({ where: { API_ID: apiId }, transaction: t });
                 created = true;
             }
         });
 
         logger.info('MCP server published', { name, version, orgHandle });
-        const schema = { tools: tools || [], resources: resources || [], prompts: prompts || [] };
+        let schema;
+        if (choreoMeta) {
+            schema = { tools, resources, prompts };
+        } else if (existingApiId) {
+            const schemaContent = await apiDao.getAPIDoc(constants.DOC_TYPES.SCHEMA_DEFINITION, orgId, existingApiId, null);
+            schema = parseSchema(schemaContent);
+        } else {
+            schema = { tools: [], resources: [], prompts: [] };
+        }
         return res.status(created ? 201 : 200).json(new ServerResponseDTO(row, schema));
     } catch (error) {
         return handleUnexpectedError(res, error, 'publishServer', 'Failed to publish server');
@@ -342,14 +369,16 @@ const updateVersion = async (req, res) => {
 
         const { title, description, _meta } = detail;
         const remotes = detail.remotes || [];
-        const choreoMeta = (_meta && _meta['io.choreo/mcp-capabilities']) || {};
-        const tools = choreoMeta.tools || [];
-        const resources = choreoMeta.resources || [];
-        const prompts = choreoMeta.prompts || [];
-        const schemaContent = JSON.stringify({ tools, resources, prompts });
-        const schemaBuffer = Buffer.from(schemaContent, 'utf-8');
+        const choreoMeta = _meta && _meta['io.api-platform/mcp-capabilities'];
+        const tools = choreoMeta?.tools || [];
+        const resources = choreoMeta?.resources || [];
+        const prompts = choreoMeta?.prompts || [];
+        const schemaBuffer = choreoMeta
+            ? Buffer.from(JSON.stringify({ tools, resources, prompts }), 'utf-8')
+            : null;
 
         let row;
+        let updatedApiId = null;
         await sequelize.transaction(async (t) => {
             const existing = await APIMetadata.findOne({
                 where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, API_NAME: serverName, API_VERSION: version },
@@ -357,21 +386,30 @@ const updateVersion = async (req, res) => {
             });
             if (!existing) return;
 
+            updatedApiId = existing.API_ID;
             const existingPublishedAt = existing.METADATA_SEARCH?.apiInfo?.publishedAt || new Date().toISOString();
             const apiMetadataPayload = buildApiMetadataPayload(serverName, version, description, remotes, title, existingPublishedAt, new Date().toISOString());
             await apiDao.updateAPIMetadata(orgId, existing.API_ID, apiMetadataPayload, t);
             await apiDao.createAPILabelMapping(orgId, existing.API_ID, ['default'], t);
-            await apiDao.updateOrCreateAPIFiles(
-                [{ content: schemaBuffer, fileName: SCHEMA_FILE_NAME, type: constants.DOC_TYPES.SCHEMA_DEFINITION }],
-                existing.API_ID, orgId, t
-            );
+            if (schemaBuffer) {
+                await apiDao.updateOrCreateAPIFiles(
+                    [{ content: schemaBuffer, fileName: SCHEMA_FILE_NAME, type: constants.DOC_TYPES.SCHEMA_DEFINITION }],
+                    existing.API_ID, orgId, t
+                );
+            }
             row = await APIMetadata.findOne({ where: { API_ID: existing.API_ID }, transaction: t });
         });
 
         if (!row) {
             return sendError(res, 404, 'Server version not found');
         }
-        const schema = { tools: tools || [], resources: resources || [], prompts: prompts || [] };
+        let schema;
+        if (choreoMeta) {
+            schema = { tools, resources, prompts };
+        } else {
+            const schemaContent = await apiDao.getAPIDoc(constants.DOC_TYPES.SCHEMA_DEFINITION, orgId, updatedApiId, null);
+            schema = parseSchema(schemaContent);
+        }
         return res.status(200).json(new ServerResponseDTO(row, schema));
     } catch (error) {
         return handleUnexpectedError(res, error, 'updateVersion', 'Failed to update server version');

--- a/src/services/mcpRegistryService.js
+++ b/src/services/mcpRegistryService.js
@@ -491,21 +491,30 @@ const updateAllVersionsStatus = async (req, res) => {
             return sendError(res, 400, 'Invalid status value');
         }
 
-        const existing = await APIMetadata.findAll({
-            where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName }
+        const dbStatus = REGISTRY_TO_DB_STATUS[status];
+        let updated;
+
+        await sequelize.transaction(async (t) => {
+            const existing = await APIMetadata.findAll({
+                where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName },
+                lock: t.LOCK.UPDATE,
+                transaction: t
+            });
+            if (existing.length === 0) return;
+
+            await APIMetadata.update(
+                { STATUS: dbStatus },
+                { where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName }, transaction: t }
+            );
+            updated = await APIMetadata.findAll({
+                where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName },
+                transaction: t
+            });
         });
-        if (existing.length === 0) {
+
+        if (!updated) {
             return sendError(res, 404, 'Server not found');
         }
-
-        const dbStatus = REGISTRY_TO_DB_STATUS[status];
-        await APIMetadata.update(
-            { STATUS: dbStatus },
-            { where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName } }
-        );
-        const updated = await APIMetadata.findAll({
-            where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName }
-        });
         return res.status(200).json({
             updatedCount: updated.length,
             servers: updated.map(row => new ServerResponseDTO(row))

--- a/src/services/mcpRegistryService.js
+++ b/src/services/mcpRegistryService.js
@@ -1,0 +1,489 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-disable no-undef */
+const { Sequelize, Op } = require('sequelize');
+const sequelize = require('../db/sequelize');
+const { APIMetadata } = require('../models/apiMetadata');
+const apiDao = require('../dao/apiMetadata');
+const adminDao = require('../dao/admin');
+const ServerResponseDTO = require('../dto/mcpServer');
+const logger = require('../config/logger');
+const constants = require('../utils/constants');
+
+const MCP_STATUSES = ['active', 'deprecated', 'deleted'];
+const SERVER_NAME_PATTERN = /^[a-zA-Z0-9.-]+\/[a-zA-Z0-9._-]+$/;
+const VERSION_RANGE_PATTERN = /^[\^~]|^>=?|^<=?|\*|(^|\.)x(\.|$)/i;
+const DEFAULT_LIMIT = 30;
+const MAX_LIMIT = 100;
+const SCHEMA_FILE_NAME = 'schema.json';
+
+// Map registry spec status values to DB STATUS values
+const REGISTRY_TO_DB_STATUS = {
+    active: 'PUBLISHED',
+    deprecated: 'DEPRECATED',
+    deleted: 'DELETED'
+};
+
+function normalizeLimit(limit) {
+    const n = parseInt(limit, 10);
+    if (Number.isNaN(n) || n <= 0) return DEFAULT_LIMIT;
+    return Math.min(n, MAX_LIMIT);
+}
+
+function parseBool(value, defaultValue) {
+    if (value === undefined || value === null || value === '') return defaultValue;
+    return String(value).toLowerCase() === 'true';
+}
+
+function validateServerDetail(detail) {
+    if (!detail || typeof detail !== 'object') {
+        return 'Request body must be a JSON object';
+    }
+    if (!detail.name || typeof detail.name !== 'string') {
+        return '"name" is required';
+    }
+    if (detail.name.length < 3 || detail.name.length > 200) {
+        return '"name" length must be between 3 and 200 characters';
+    }
+    if (!SERVER_NAME_PATTERN.test(detail.name)) {
+        return '"name" must match reverse-DNS pattern "namespace/server"';
+    }
+    if (typeof detail.description !== 'string') {
+        return '"description" is required';
+    }
+    if (!detail.version || typeof detail.version !== 'string') {
+        return '"version" is required';
+    }
+    if (detail.version === 'latest') {
+        return '"version" cannot be the reserved value "latest"';
+    }
+    if (VERSION_RANGE_PATTERN.test(detail.version)) {
+        return '"version" must be a specific version, not a range';
+    }
+    return null;
+}
+
+function sendError(res, status, message) {
+    return res.status(status).json({ error: message });
+}
+
+function handleUnexpectedError(res, error, operation, fallbackMessage) {
+    logger.error('MCP registry operation failed', {
+        operation,
+        error: error.message,
+        stack: error.stack
+    });
+    if (error instanceof Sequelize.ValidationError) {
+        return sendError(res, 400, error.message);
+    }
+    if (error instanceof Sequelize.UniqueConstraintError) {
+        return sendError(res, 409, 'Server version already exists');
+    }
+    if (error instanceof Sequelize.EmptyResultError) {
+        return sendError(res, 404, 'Organization not found');
+    }
+    return sendError(res, 500, fallbackMessage);
+}
+
+/**
+ * Resolves orgId UUID from the orgHandle path parameter.
+ * Throws Sequelize.EmptyResultError if org not found.
+ */
+async function resolveOrgId(orgHandle) {
+    return adminDao.getOrgId(orgHandle);
+}
+
+/**
+ * Builds the apiMetadata shape expected by apiDao.createAPIMetadata / updateAPIMetadata.
+ */
+function buildApiMetadataPayload(name, version, description, remotes, title, publishedAt, updatedAt) {
+    const normalizedRemotes = (Array.isArray(remotes) ? remotes : []).map(r => ({
+        type: r.type || 'streamable-http',
+        url: r.url || ''
+    }));
+    const primaryUrl = normalizedRemotes.length > 0 ? normalizedRemotes[0].url : '';
+    return {
+        apiInfo: {
+            referenceID: null,
+            provider: 'WSO2',
+            apiName: name,
+            apiHandle: name.replace('/', '-'),
+            apiTitle: title || null,
+            apiDescription: description || `${name} MCP proxy`,
+            apiVersion: version,
+            apiType: constants.API_TYPE.MCP,
+            apiStatus: 'PUBLISHED',
+            visibility: 'PUBLIC',
+            tokenBasedSubscriptionEnabled: false,
+            gatewayType: null,
+            remotes: normalizedRemotes,
+            publishedAt: publishedAt || null,
+            updatedAt: updatedAt || null
+        },
+        endPoints: {
+            productionURL: primaryUrl,
+            sandboxURL: null
+        }
+    };
+}
+
+/**
+ * Parses schema content from a DP_API_CONTENT row's API_FILE buffer.
+ */
+function parseSchema(contentRow) {
+    if (!contentRow) return null;
+    try {
+        const raw = contentRow.API_FILE;
+        const str = Buffer.isBuffer(raw) ? raw.toString('utf-8') : String(raw);
+        return JSON.parse(str);
+    } catch (e) {
+        logger.warn('Failed to parse MCP schema content', { error: e.message });
+        return null;
+    }
+}
+
+// ─── Public discovery endpoints ──────────────────────────────────────────────
+
+const listServers = async (req, res) => {
+    try {
+        const orgHandle = req.params.orgHandle;
+        const orgId = await resolveOrgId(orgHandle);
+        const includeDeleted = parseBool(req.query.include_deleted, false);
+        const limit = normalizeLimit(req.query.limit);
+        const search = req.query.search;
+
+        const where = { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP };
+        if (!includeDeleted) {
+            where.STATUS = { [Op.ne]: 'DELETED' };
+        }
+        if (search) {
+            where.API_NAME = { [Op.iLike]: `%${search}%` };
+        }
+
+        const rows = await APIMetadata.findAll({
+            where,
+            order: [[sequelize.literal("(\"METADATA_SEARCH\"->'apiInfo'->>'publishedAt')"), 'DESC NULLS LAST']],
+            limit: limit + 1
+        });
+
+        const hasMore = rows.length > limit;
+        const pageRows = hasMore ? rows.slice(0, limit) : rows;
+        const metadata = { count: pageRows.length };
+        if (hasMore) {
+            metadata.nextCursor = Buffer.from(JSON.stringify({ offset: limit })).toString('base64url');
+        }
+
+        return res.status(200).json({
+            servers: pageRows.map(row => new ServerResponseDTO(row)),
+            metadata
+        });
+    } catch (error) {
+        return handleUnexpectedError(res, error, 'listServers', 'Failed to list servers');
+    }
+};
+
+const listVersions = async (req, res) => {
+    try {
+        const orgHandle = req.params.orgHandle;
+        const orgId = await resolveOrgId(orgHandle);
+        const serverName = decodeURIComponent(req.params.serverName);
+        const includeDeleted = parseBool(req.query.include_deleted, false);
+
+        const where = { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, API_NAME: serverName };
+        if (!includeDeleted) {
+            where.STATUS = { [Op.ne]: 'DELETED' };
+        }
+
+        const rows = await APIMetadata.findAll({
+            where,
+            order: [[sequelize.literal("(\"METADATA_SEARCH\"->'apiInfo'->>'publishedAt')"), 'DESC NULLS LAST']]
+        });
+
+        if (rows.length === 0) {
+            return sendError(res, 404, 'Server not found');
+        }
+
+        return res.status(200).json({
+            servers: rows.map(row => new ServerResponseDTO(row)),
+            metadata: { count: rows.length }
+        });
+    } catch (error) {
+        return handleUnexpectedError(res, error, 'listVersions', 'Failed to list server versions');
+    }
+};
+
+const getVersion = async (req, res) => {
+    try {
+        const orgHandle = req.params.orgHandle;
+        const orgId = await resolveOrgId(orgHandle);
+        const serverName = decodeURIComponent(req.params.serverName);
+        const version = decodeURIComponent(req.params.version);
+
+        const where = {
+            ORG_ID: orgId,
+            API_TYPE: constants.API_TYPE.MCP,
+            API_NAME: serverName,
+            API_VERSION: version
+        };
+        if (!parseBool(req.query.include_deleted, false)) {
+            where.STATUS = { [Op.ne]: 'DELETED' };
+        }
+
+        const row = await APIMetadata.findOne({ where });
+        if (!row) {
+            return sendError(res, 404, 'Server not found');
+        }
+
+        const schemaContent = await apiDao.getAPIDoc(
+            constants.DOC_TYPES.SCHEMA_DEFINITION, orgId, row.API_ID, null
+        );
+        const schema = parseSchema(schemaContent);
+
+        return res.status(200).json(new ServerResponseDTO(row, schema));
+    } catch (error) {
+        return handleUnexpectedError(res, error, 'getVersion', 'Failed to get server version');
+    }
+};
+
+// ─── Write endpoints ──────────────────────────────────────────────────────────
+
+const publishServer = async (req, res) => {
+    try {
+        const orgHandle = req.params.orgHandle;
+        const detail = req.body;
+
+        const validationError = validateServerDetail(detail);
+        if (validationError) {
+            return sendError(res, 400, validationError);
+        }
+
+        const orgId = await resolveOrgId(orgHandle);
+        const { name, version, title, description, _meta, mcpData } = detail;
+        const remotes = mcpData?.remotes || detail.remotes || [];
+        const choreoMeta = (_meta && _meta['io.choreo/mcp-capabilities']) || {};
+        const tools = choreoMeta.tools || [];
+        const resources = choreoMeta.resources || [];
+        const prompts = choreoMeta.prompts || [];
+        const now = new Date().toISOString();
+        const schemaContent = JSON.stringify({ tools, resources, prompts });
+        const schemaBuffer = Buffer.from(schemaContent, 'utf-8');
+
+        let row;
+        let created = false;
+
+        await sequelize.transaction(async (t) => {
+            const existing = await APIMetadata.findOne({
+                where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, API_NAME: name, API_VERSION: version },
+                transaction: t
+            });
+
+            if (existing) {
+                const existingPublishedAt = existing.METADATA_SEARCH?.apiInfo?.publishedAt || now;
+                const apiMetadataPayload = buildApiMetadataPayload(name, version, description, remotes, title, existingPublishedAt, now);
+                await apiDao.updateAPIMetadata(orgId, existing.API_ID, apiMetadataPayload, t);
+                await apiDao.createAPILabelMapping(orgId, existing.API_ID, ['default'], t);
+                await apiDao.updateOrCreateAPIFiles(
+                    [{ content: schemaBuffer, fileName: SCHEMA_FILE_NAME, type: constants.DOC_TYPES.SCHEMA_DEFINITION }],
+                    existing.API_ID, orgId, t
+                );
+                row = await APIMetadata.findOne({ where: { API_ID: existing.API_ID }, transaction: t });
+            } else {
+                const apiMetadataPayload = buildApiMetadataPayload(name, version, description, remotes, title, now, now);
+                const created_row = await apiDao.createAPIMetadata(orgId, apiMetadataPayload, t);
+                const apiId = created_row.dataValues.API_ID;
+                await apiDao.createAPILabelMapping(orgId, apiId, ['default'], t);
+                await apiDao.storeAPIFile(schemaBuffer, SCHEMA_FILE_NAME, apiId, constants.DOC_TYPES.SCHEMA_DEFINITION, t);
+                row = await APIMetadata.findOne({ where: { API_ID: apiId }, transaction: t });
+                created = true;
+            }
+        });
+
+        logger.info('MCP server published', { name, version, orgHandle });
+        const schema = { tools: tools || [], resources: resources || [], prompts: prompts || [] };
+        return res.status(created ? 201 : 200).json(new ServerResponseDTO(row, schema));
+    } catch (error) {
+        return handleUnexpectedError(res, error, 'publishServer', 'Failed to publish server');
+    }
+};
+
+const updateVersion = async (req, res) => {
+    try {
+        const orgHandle = req.params.orgHandle;
+        const orgId = await resolveOrgId(orgHandle);
+        const serverName = decodeURIComponent(req.params.serverName);
+        const version = decodeURIComponent(req.params.version);
+        const detail = req.body;
+
+        const validationError = validateServerDetail(detail);
+        if (validationError) {
+            return sendError(res, 400, validationError);
+        }
+        if (detail.name !== serverName) {
+            return sendError(res, 400, 'Server name in body must match path');
+        }
+        if (detail.version !== version) {
+            return sendError(res, 400, 'Version in body must match path');
+        }
+
+        const { title, description, _meta, mcpData } = detail;
+        const remotes = mcpData?.remotes || detail.remotes || [];
+        const choreoMeta = (_meta && _meta['io.choreo/mcp-capabilities']) || {};
+        const tools = choreoMeta.tools || [];
+        const resources = choreoMeta.resources || [];
+        const prompts = choreoMeta.prompts || [];
+        const schemaContent = JSON.stringify({ tools, resources, prompts });
+        const schemaBuffer = Buffer.from(schemaContent, 'utf-8');
+
+        let row;
+        await sequelize.transaction(async (t) => {
+            const existing = await APIMetadata.findOne({
+                where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, API_NAME: serverName, API_VERSION: version },
+                transaction: t
+            });
+            if (!existing) return;
+
+            const existingPublishedAt = existing.METADATA_SEARCH?.apiInfo?.publishedAt || new Date().toISOString();
+            const apiMetadataPayload = buildApiMetadataPayload(serverName, version, description, remotes, title, existingPublishedAt, new Date().toISOString());
+            await apiDao.updateAPIMetadata(orgId, existing.API_ID, apiMetadataPayload, t);
+            await apiDao.createAPILabelMapping(orgId, existing.API_ID, ['default'], t);
+            await apiDao.updateOrCreateAPIFiles(
+                [{ content: schemaBuffer, fileName: SCHEMA_FILE_NAME, type: constants.DOC_TYPES.SCHEMA_DEFINITION }],
+                existing.API_ID, orgId, t
+            );
+            row = await APIMetadata.findOne({ where: { API_ID: existing.API_ID }, transaction: t });
+        });
+
+        if (!row) {
+            return sendError(res, 404, 'Server version not found');
+        }
+        const schema = { tools: tools || [], resources: resources || [], prompts: prompts || [] };
+        return res.status(200).json(new ServerResponseDTO(row, schema));
+    } catch (error) {
+        return handleUnexpectedError(res, error, 'updateVersion', 'Failed to update server version');
+    }
+};
+
+const deleteVersion = async (req, res) => {
+    try {
+        const orgHandle = req.params.orgHandle;
+        const orgId = await resolveOrgId(orgHandle);
+        const serverName = decodeURIComponent(req.params.serverName);
+        const version = decodeURIComponent(req.params.version);
+
+        const existing = await APIMetadata.findOne({
+            where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName, API_VERSION: version }
+        });
+        if (!existing) {
+            return sendError(res, 404, 'Server version not found');
+        }
+
+        await sequelize.transaction(async (t) => {
+            await APIMetadata.update(
+                { STATUS: 'DELETED' },
+                { where: { API_ID: existing.API_ID, ORG_ID: orgId }, transaction: t }
+            );
+        });
+        logger.info('MCP server deleted', { name: serverName, version, orgHandle });
+        return res.status(200).json(new ServerResponseDTO(
+            Object.assign(existing.get({ plain: true }), { STATUS: 'DELETED' })
+        ));
+    } catch (error) {
+        return handleUnexpectedError(res, error, 'deleteVersion', 'Failed to delete server version');
+    }
+};
+
+const updateVersionStatus = async (req, res) => {
+    try {
+        const orgHandle = req.params.orgHandle;
+        const orgId = await resolveOrgId(orgHandle);
+        const serverName = decodeURIComponent(req.params.serverName);
+        const version = decodeURIComponent(req.params.version);
+        const { status } = req.body || {};
+
+        if (!status || !MCP_STATUSES.includes(status)) {
+            return sendError(res, 400, 'Invalid status value');
+        }
+
+        const existing = await APIMetadata.findOne({
+            where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName, API_VERSION: version }
+        });
+        if (!existing) {
+            return sendError(res, 404, 'Server version not found');
+        }
+
+        const dbStatus = REGISTRY_TO_DB_STATUS[status];
+        if (existing.STATUS === dbStatus) {
+            return sendError(res, 400, `No changes to apply: status is already ${status}`);
+        }
+
+        await APIMetadata.update(
+            { STATUS: dbStatus },
+            { where: { API_ID: existing.API_ID, ORG_ID: orgId } }
+        );
+        const updated = await APIMetadata.findOne({ where: { API_ID: existing.API_ID } });
+        return res.status(200).json(new ServerResponseDTO(updated));
+    } catch (error) {
+        return handleUnexpectedError(res, error, 'updateVersionStatus', 'Failed to update server status');
+    }
+};
+
+const updateAllVersionsStatus = async (req, res) => {
+    try {
+        const orgHandle = req.params.orgHandle;
+        const orgId = await resolveOrgId(orgHandle);
+        const serverName = decodeURIComponent(req.params.serverName);
+        const { status } = req.body || {};
+
+        if (!status || !MCP_STATUSES.includes(status)) {
+            return sendError(res, 400, 'Invalid status value');
+        }
+
+        const existing = await APIMetadata.findAll({
+            where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName }
+        });
+        if (existing.length === 0) {
+            return sendError(res, 404, 'Server not found');
+        }
+
+        const dbStatus = REGISTRY_TO_DB_STATUS[status];
+        await APIMetadata.update(
+            { STATUS: dbStatus },
+            { where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName } }
+        );
+        const updated = await APIMetadata.findAll({
+            where: { ORG_ID: orgId, API_TYPE: constants.API_TYPE.MCP, REFERENCE_ID: null, API_NAME: serverName }
+        });
+        return res.status(200).json({
+            updatedCount: updated.length,
+            servers: updated.map(row => new ServerResponseDTO(row))
+        });
+    } catch (error) {
+        return handleUnexpectedError(res, error, 'updateAllVersionsStatus', 'Failed to update server status');
+    }
+};
+
+module.exports = {
+    listServers,
+    listVersions,
+    getVersion,
+    publishServer,
+    updateVersion,
+    deleteVersion,
+    updateVersionStatus,
+    updateAllVersionsStatus
+};

--- a/src/services/mcpRegistryService.js
+++ b/src/services/mcpRegistryService.js
@@ -273,8 +273,8 @@ const publishServer = async (req, res) => {
         }
 
         const orgId = await resolveOrgId(orgHandle);
-        const { name, version, title, description, _meta, mcpData } = detail;
-        const remotes = mcpData?.remotes || detail.remotes || [];
+        const { name, version, title, description, _meta } = detail;
+        const remotes = detail.remotes || [];
         const choreoMeta = (_meta && _meta['io.choreo/mcp-capabilities']) || {};
         const tools = choreoMeta.tools || [];
         const resources = choreoMeta.resources || [];
@@ -340,8 +340,8 @@ const updateVersion = async (req, res) => {
             return sendError(res, 400, 'Version in body must match path');
         }
 
-        const { title, description, _meta, mcpData } = detail;
-        const remotes = mcpData?.remotes || detail.remotes || [];
+        const { title, description, _meta } = detail;
+        const remotes = detail.remotes || [];
         const choreoMeta = (_meta && _meta['io.choreo/mcp-capabilities']) || {};
         const tools = choreoMeta.tools || [];
         const resources = choreoMeta.resources || [];

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1039,6 +1039,10 @@ function filterAllowedAPIs(searchResults, allowedAPIs) {
         if (constants.FEDERATED_GATEWAY_VENDORS.includes(gatewayVendor)) {
             return true;
         }
+        // MCP servers published via the registry have no referenceID – skip control plane check
+        if (api?.apiInfo?.apiType === constants.API_TYPE.MCP && !api.apiReferenceID) {
+            return true;
+        }
         return allowedAPIs.some(allowedAPI => api.apiReferenceID === allowedAPI.id);
     });
     return searchResults;


### PR DESCRIPTION
## Purpose

This pull request introduces significant improvements to the handling and display of MCP (Multi-Cloud Platform) APIs, especially those sourced from the registry, as well as UI enhancements for better metadata presentation. The changes focus on correctly distinguishing registry-based MCP APIs, improving schema and documentation rendering, and polishing the display of API titles and details.

## Approach

**MCP API Handling and Registry Integration:**

* Added a new route (`mcpRegistryRoute`) and backend logic to support MCP APIs directly from the registry, bypassing control plane checks for these APIs. [[1]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R39) [[2]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R591-R592) [[3]](diffhunk://#diff-aa605e323bf911feb9c3d3259559e2d06e8c0c8cda729101c8ce0a9f4f5816c0L283-R284) [[4]](diffhunk://#diff-aa605e323bf911feb9c3d3259559e2d06e8c0c8cda729101c8ce0a9f4f5816c0R657-R659)
* Enhanced the logic for loading API content and documents to properly handle registry-based MCP APIs, including correct schema loading, server URL extraction, and documentation sidebar rendering when doc types are missing. [[1]](diffhunk://#diff-aa605e323bf911feb9c3d3259559e2d06e8c0c8cda729101c8ce0a9f4f5816c0R383-L397) [[2]](diffhunk://#diff-aa605e323bf911feb9c3d3259559e2d06e8c0c8cda729101c8ce0a9f4f5816c0L691-R704) [[3]](diffhunk://#diff-aa605e323bf911feb9c3d3259559e2d06e8c0c8cda729101c8ce0a9f4f5816c0L788-R808)
* Updated API definition retrieval and display logic to account for MCP APIs, ensuring that Swagger and GraphQL definitions are handled appropriately. [[1]](diffhunk://#diff-aa605e323bf911feb9c3d3259559e2d06e8c0c8cda729101c8ce0a9f4f5816c0L520-R529) [[2]](diffhunk://#diff-aa605e323bf911feb9c3d3259559e2d06e8c0c8cda729101c8ce0a9f4f5816c0L342-R344)

**UI and Template Improvements:**

* Improved the MCP landing page (`mcp-default.hbs`) to conditionally display Tools, Resources, and Prompts sections based on schema content, and fixed server URL rendering to remove unnecessary `/mcp` suffix. [[1]](diffhunk://#diff-534c336e23a42db5a8ffec76a742a3735a1f4760a5cd4ad292f505a8ebac382aL34-R34) [[2]](diffhunk://#diff-534c336e23a42db5a8ffec76a742a3735a1f4760a5cd4ad292f505a8ebac382aR46-R50) [[3]](diffhunk://#diff-534c336e23a42db5a8ffec76a742a3735a1f4760a5cd4ad292f505a8ebac382aR72-R128) [[4]](diffhunk://#diff-534c336e23a42db5a8ffec76a742a3735a1f4760a5cd4ad292f505a8ebac382aL78-R137)
* Updated the MCP detail banner and listing templates to prioritize displaying `apiTitle` (if present) over `apiName`, and refined logic for showing subscribe/documentation buttons based on API type and registry status. [[1]](diffhunk://#diff-abfcdf25224dcbd24617c8d615560376f417f921a0ec54e4eb43eb45dc51e9c5L7-R7) [[2]](diffhunk://#diff-abfcdf25224dcbd24617c8d615560376f417f921a0ec54e4eb43eb45dc51e9c5R17-R28) [[3]](diffhunk://#diff-abfcdf25224dcbd24617c8d615560376f417f921a0ec54e4eb43eb45dc51e9c5L30-R38) [[4]](diffhunk://#diff-3fd9940969e7f543d6901b7633221135faa60df7eb41dc5341c4ca9c3f1a20b3L69-R72)

**Handlebars and Utility Enhancements:**

* Added a new Handlebars helper `or` to simplify conditional rendering in templates, particularly for displaying either `apiTitle` or `apiName`.

**Minor Backend Fixes:**

* Updated the label creation logic to ignore duplicate entries during bulk creation, preventing errors when labels already exist.
* Extended the `APIInfo` DTO to include `apiTitle` and `remotes` properties, supporting the new UI and backend logic.