### PR TITLE
Add endpoint for LLMS API documentation

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -368,21 +368,17 @@ app.get('/robots.txt', (req, res) => {
 });
 
 app.get('/llms.txt', (req, res) => {
-    const baseUrl = `${req.protocol}://${req.get('host')}`;
+    const baseUrl = config.baseUrl;
     res.type('text/plain').send(
         `# API Developer Portal — AI Agent Entry Point\n\n` +
-        `This portal hosts APIs organized by organization and view.\n\n` +
-        `## If you already have a portal URL\n\n` +
-        `If the user provided a URL such as:\n\n` +
-        `  https://host/{orgName}/views/{viewName}\n\n` +
-        `Extract the \`{orgName}\` and \`{viewName}\` from it and fetch directly:\n\n` +
+        `This portal provides APIs, MCP servers, and API workflows organized by organization and view.\n` +
+        `The portal host is the origin you fetched this file from: ${baseUrl}\n\n` +
+        `## Exploring APIs\n\n` +
+        `To discover APIs, MCP servers, and API workflows published by an organization, fetch the org/view-specific index:\n\n` +
         `  ${baseUrl}/{orgName}/views/{viewName}/llms.txt\n\n` +
-        `## If you do not have a portal URL\n\n` +
-        `If the user has already provided an organization name, use it directly:\n\n` +
-        `  ${baseUrl}/{orgName}/views/default/llms.txt\n\n` +
-        `If the user also specified a view name, replace \`default\` with it.\n\n` +
-        `If you have neither a URL nor an organization name, ask the user:\n` +
-        `"Which organization's APIs would you like to explore?"\n`
+        `If the user has provided a URL that contains the organization name and view name, extract them from it.\n\n` +
+        `If the organization name is not known, ask the user to provide it — do not guess.\n` +
+        `If the view name is not specified, use \`default\`.\n`
     );
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -367,6 +367,25 @@ app.get('/robots.txt', (req, res) => {
     );
 });
 
+app.get('/llms.txt', (req, res) => {
+    const baseUrl = `${req.protocol}://${req.get('host')}`;
+    res.type('text/plain').send(
+        `# API Developer Portal — AI Agent Entry Point\n\n` +
+        `This portal hosts APIs organized by organization and view.\n\n` +
+        `## If you already have a portal URL\n\n` +
+        `If the user provided a URL such as:\n\n` +
+        `  https://host/{orgName}/views/{viewName}\n\n` +
+        `Extract the \`{orgName}\` and \`{viewName}\` from it and fetch directly:\n\n` +
+        `  ${baseUrl}/{orgName}/views/{viewName}/llms.txt\n\n` +
+        `## If you do not have a portal URL\n\n` +
+        `If the user has already provided an organization name, use it directly:\n\n` +
+        `  ${baseUrl}/{orgName}/views/default/llms.txt\n\n` +
+        `If the user also specified a view name, replace \`default\` with it.\n\n` +
+        `If you have neither a URL nor an organization name, ask the user:\n` +
+        `"Which organization's APIs would you like to explore?"\n`
+    );
+});
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION
## Purpose

When only the portal url is given to an agent and asked to explore apis of a specific org, it tries to find the llms.txt from (https://devportal.preview-dv.bijira.dev/llms.txt. Therefore, we are adding this to guide the agent to refer to the correct llms.txt file provided for a specific tenant.
```
❯ Can you get the APIs from this devportal and list with the description - https://devportal.preview-dv.bijira.dev/aiorg/views/default                   

⏺ I'll fetch the dev portal page to find the APIs.

⏺ Fetch(https://devportal.preview-dv.bijira.dev/aiorg/views/default)
  ⎿  Received 1KB (302 Found)

⏺ The portal requires authentication (it redirects to an OAuth2 login via Asgardeo). I can't access it directly without credentials.

  To proceed, you could:
  1. Share your credentials/token — if you have an access token for this portal, I can use it in a request header.
  2. Export the API list — log in to the portal yourself and share the page content or a JSON export.
  3. Check for a public llms.txt or API spec — some portals expose a /llms.txt or OpenAPI spec at a public path (e.g.,
  https://devportal.preview-dv.bijira.dev/llms.txt). Want me to try that?

❯ yes pls try finding an llms.txt                                                                                                                        

⏺ Fetch(https://devportal.preview-dv.bijira.dev/llms.txt)
  ⎿  Received 2.3KB (200 OK)

⏺ The /llms.txt path also redirects to the login page. Let me try a couple of other common paths.

⏺ Fetch(https://devportal.preview-dv.bijira.dev/aiorg/llms.txt)
  ⎿  Received 2.3KB (200 OK)
```


# Root llms.txt

# API Developer Portal — AI Agent Entry Point

This portal provides APIs, MCP servers, and API workflows organized by organization and view.
The portal host is the origin you fetched this file from: https://localhost:3000

## Exploring APIs

To discover APIs, MCP servers, and API workflows published by an organization, fetch the org/view-specific index:

  https://localhost:3000/{orgName}/views/{viewName}/llms.txt

If the user has provided a URL that contains the organization name and view name, extract them from it.

If the organization name is not known, ask the user to provide it — do not guess.
If the view name is not specified, use `default`.