### PR TITLE
Enhance llms.txt discovery by injecting HTTP Link headers and <link> …

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -362,9 +362,42 @@ const billingController = require('./controllers/billingController');
 app.post('/webhooks/stripe/:orgId', express.raw({ type: 'application/json' }), billingController.handleStripeWebhook);
 
 app.get('/robots.txt', (req, res) => {
+    const baseUrl = config.baseUrl || '';
     res.type('text/plain').send(
-        'User-agent: *\nAllow: /\n\n# AI agent guidance: /{orgName}/views/{viewName}/llms.txt\n'
+        'User-agent: *\nAllow: /\n\n' +
+        `# AI agent entry point: ${baseUrl}/llms.txt\n`
     );
+});
+
+// Inject /llms.txt discovery on root pages
+app.use('/', (req, res, next) => {
+    if (req.path !== '/') return next();
+    res.set('Link', '</llms.txt>; rel="describedby"; type="text/plain"');
+    const originalSend = res.send.bind(res);
+    res.send = function (body) {
+        if (typeof body === 'string' && body.includes('</head>')) {
+            body = body.replace('</head>',
+                `  <link rel="alternate" type="text/plain" href="/llms.txt">\n</head>`);
+        }
+        return originalSend(body);
+    };
+    next();
+});
+
+// Inject llms.txt discovery into portal view pages via HTTP Link header and <link> tag
+app.use('/:orgName/views/:viewName', (req, res, next) => {
+    const { orgName, viewName } = req.params;
+    const llmsUrl = `/${orgName}/views/${viewName}/llms.txt`;
+    res.set('Link', `<${llmsUrl}>; rel="describedby"; type="text/plain"`);
+    const originalSend = res.send.bind(res);
+    res.send = function (body) {
+        if (typeof body === 'string' && body.includes('</head>')) {
+            body = body.replace('</head>',
+                `  <link rel="alternate" type="text/plain" href="${llmsUrl}">\n</head>`);
+        }
+        return originalSend(body);
+    };
+    next();
 });
 
 app.get('/llms.txt', (req, res) => {


### PR DESCRIPTION
# Problem                                                                                                                                        
                                                            
  AI agents given just a portal URL (e.g. https://localhost:3000/aiorg/views/default) had no way to automatically discover the llms.txt file at  
  /{orgName}/views/{viewName}/llms.txt. The root /llms.txt already existed but wasn't signaled anywhere.
                                                                                                                                                 
  ---                                                       
  **What We Discussed**
                   
  Why agents couldn't auto-discover llms.txt:
  - The file lives at a deep path, not the domain root                                                                                           
  - No HTTP or HTML signals were pointing to it                                                                                                  
  - robots.txt only had a vague placeholder comment                                                                                              
  - <link> tags and Link headers aren't automatically followed by most LLMs today (including Claude) — they require an explicit prompt or tool   
  that respects those conventions                                                                                                                
  - The most reliable discovery mechanism is the root /llms.txt convention (from llmstxt.org), which some tools like Cursor and Perplexity       
  already check automatically                                                                                                                    
                                                                                                                                                 
  What we ruled out:                                        
  - Meta tags — no recognized standard for llms.txt, would be ignored                                                                            
  - JS-injected <link> tag — useless for curl/headless agents        
  - The <link> tag alone — agents don't automatically follow it
                                                                                                                                                 
  ---
  **Fixes Applied**                                                                                                                                  
                                                            
  1. robots.txt — points agents to /llms.txt                                                                                                     
                                                                                                                                                 
  User-agent: *
  Allow: /                                                                                                                                       
                                                            
  AI agent entry point: https://your-domain/llms.txt                                                                                           
   
  2. Root / middleware — signals /llms.txt                                                                                                       
                                                            
  Any agent hitting the root URL now gets:                                                                                                       
  - HTTP header: Link: </llms.txt>; rel="describedby"; type="text/plain"
  - HTML: <link rel="alternate" type="text/plain" href="/llms.txt"> injected before </head> server-side                                          
                                                                                                       
  3. Portal view middleware — signals the view-specific llms.txt                                                                                 
                                                                                                                                                 
  Any page under /:orgName/views/:viewName/* now gets:                                                                                           
  - HTTP header: Link: </aiorg/views/default/llms.txt>; rel="describedby"; type="text/plain"                                                     
  - HTML: <link rel="alternate" type="text/plain" href="/aiorg/views/default/llms.txt"> injected server-side (no script tag)                     
                                                                                                                            
  Both 2 and 3 are handled by response-intercepting middleware in app.js — no template or controller changes needed.                             
                                                                                                                                                 
  ---                                                                                                                                            
  **Discovery Chain for an Agent**                                                                                                                   
                                                                                                                                                 
  GET /                    → Link header + <link> tag → /llms.txt
  GET /llms.txt            → root index, instructs agent to fetch /{orgName}/views/{viewName}/llms.txt                                           
  GET /aiorg/views/default → Link header + <link> tag → /aiorg/views/default/llms.txt                                                            
  GET /aiorg/views/default/llms.txt → full API catalog


 ---                                                                                                                                            
  **Claude (claude.ai / Claude Code)**
                                                                                                                                                 
  Does NOT auto-discover. When given a URL, I fetch the page and read the HTML text content — but I don't automatically follow Link headers or
  <link> tags, and I don't check /llms.txt first by default. The user needs to either:                                                           
  - Explicitly tell me to read the llms.txt URL, OR         
  - Have the llms.txt URL visible as readable text in the page content                                                                           
                                                                      
  That's exactly what your home-discover.js does — it generates a prompt that tells Claude where to find llms.txt. That's the right workaround   
  for now.                                                                                                                                       
                                                                                                                                                 
  ---                                                                                                                                            
  **Cursor**                                                    
                                                                                                                                                 
  Partial support. Cursor's @Docs feature can index documentation sites. If you add a portal URL, it crawls it. Whether it automatically picks up
   llms.txt depends on the version — newer versions have added llms.txt awareness for their docs indexer. The <link> tag and Link header we added
   would help here.                                         
                                                                                                                                                 
  ---                                                       
  **Codex (OpenAI)**
                
  No auto-discovery. Similar to Claude — it doesn't check /llms.txt automatically. Needs an explicit prompt or system instruction pointing to the
   URL.                                                                                                                                          
  
  ---                                                                                                                                            
  Bottom Line                                               
             
<html><head></head><body>
Tool | Auto-checks /llms.txt | Follows Link header | Needs explicit prompt
-- | -- | -- | --
Claude | No | No | Yes
Cursor (@Docs) | Partially | Possibly | Sometimes
Codex | No | No | Yes

</body></html>                                          
  
  The llms.txt standard is still early. The most reliable path for all three today is what you already have — the "Run in Claude" / copy prompt  
  flow in home-discover.js that gives the agent the exact URL. The signals we added (Link header, <link> tag, root /llms.txt) are future-proofing
   for when tools adopt the standard more broadly.      