### PR TITLE
Add cache control headers to API response for llms.txt and markdown endpoints

### DIFF
--- a/src/controllers/apiContentController.js
+++ b/src/controllers/apiContentController.js
@@ -1473,6 +1473,9 @@ const loadLlmsTxt = async (req, res) => {
 
         const md = await util.renderLlmsTxt(templateContent, orgID, viewName);
         res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+        res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+        res.setHeader('Pragma', 'no-cache');
+        res.setHeader('Expires', '0');
         res.send(md);
     } catch (error) {
         logger.error('Error generating llms.txt', { orgName, error: error.message, stack: error.stack });
@@ -1495,6 +1498,9 @@ const previewLlmsTxt = async (req, res) => {
 
         const md = await util.renderLlmsTxt(templateContent, orgID, viewName);
         res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+        res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+        res.setHeader('Pragma', 'no-cache');
+        res.setHeader('Expires', '0');
         res.send(md);
     } catch (error) {
         logger.error('Error previewing llms.txt', { orgName, error: error.message, stack: error.stack });
@@ -1537,6 +1543,9 @@ const loadAPIsMd = async (req, res) => {
         const md = await util.renderMarkdownTemplateFromAPI(templateContent, orgID, 'pages/apis', viewName);
 
         res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+        res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+        res.setHeader('Pragma', 'no-cache');
+        res.setHeader('Expires', '0');
         res.send(md);
     } catch (error) {
         logger.error('Error generating APIs markdown', {
@@ -1575,6 +1584,9 @@ const loadMCPsMd = async (req, res) => {
         const md = await util.renderMarkdownTemplateFromAPI(templateContent, orgID, 'pages/mcps', viewName);
 
         res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+        res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+        res.setHeader('Pragma', 'no-cache');
+        res.setHeader('Expires', '0');
         res.send(md);
     } catch (error) {
         logger.error('Error generating MCPs markdown', {


### PR DESCRIPTION
$subject

https://github.com/wso2-enterprise/apim-saas/issues/2501

**Fix: Prevent caching of llms.txt to ensure AI agents always retrieve up-to-date API catalog**

Occasionally, AI web agents (Claude ai) were fetching a cached version of llms.txt, causing newly added or updated APIs to not be reflected when the portal was explored by an agent.
Added the following response headers to the llms.txt endpoint to disable caching at all layers :
```
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Expires: 0
```

This ensures every request to llms.txt always returns the latest API catalog content directly from the origin server.
