### PR TITLE
Devportal OpenAPI Spec Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ config*.yaml
 resources/default-layout
 resources/mock
 
+config.yaml
+.env
+

--- a/docs/devportal-openapi-spec-v1.yaml
+++ b/docs/devportal-openapi-spec-v1.yaml
@@ -1015,6 +1015,106 @@ paths:
         - OAuth2Security:
             - dp:app_import
             - dp:app_manage
+  /applications:
+    post:
+      tags:
+        - Applications
+      summary: Create an application for the authenticated user's organization
+      description: >-
+        Creates a Developer Portal application in the organization resolved from the authenticated user's
+        organization identifier. The request may be JSON, multipart form fields, or an application YAML
+        file in the `application` multipart field.
+      operationId: saveApplication
+      requestBody:
+        $ref: "#/components/requestBodies/ApplicationMultipartBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/ApplicationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_write
+            - dp:app_manage
+  /applications/{applicationId}:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+    put:
+      tags:
+        - Applications
+      summary: Update an application for the authenticated user
+      description: >-
+        Updates an application owned by the authenticated user in the organization resolved from the
+        authenticated user's organization identifier. The request may be JSON, multipart form fields, or
+        an application YAML file in the `application` multipart field.
+      operationId: updateApplication
+      requestBody:
+        $ref: "#/components/requestBodies/ApplicationMultipartBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_write
+            - dp:app_manage
+    delete:
+      tags:
+        - Applications
+      summary: Delete an application for the authenticated user
+      description: >-
+        Deletes an application owned by the authenticated user. If the application has billed Stripe
+        subscriptions, the service cancels them before deleting the local application. If a control-plane
+        application mapping exists, the corresponding control-plane application is deleted as well.
+      operationId: deleteApplication
+      responses:
+        "200":
+          $ref: "#/components/responses/TextMessageResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_delete
+            - dp:app_manage
+  /applications/{applicationId}/reset-throttle-policy:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+    post:
+      tags:
+        - Applications
+      summary: Reset application throttle policy
+      description: >-
+        Resets throttling policy state for a control-plane application. The request is proxied to the
+        control plane using the supplied user name.
+      operationId: resetThrottlingPolicy
+      requestBody:
+        $ref: "#/components/requestBodies/ResetThrottlePolicyBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_write
+            - dp:app_manage
   /organizations/{orgId}/api-platform-subscriptions:
     parameters:
       - $ref: "#/components/parameters/OrgId"
@@ -3515,6 +3615,15 @@ components:
               summary: Application YAML upload
               value:
                 application: application.yaml
+    ResetThrottlePolicyBody:
+      required: true
+      description: User throttle policy reset payload.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ResetThrottlePolicyRequest"
+          example:
+            userName: alice@example.com
     ImportApplicationMultipartBody:
       required: true
       description: >-
@@ -5257,6 +5366,16 @@ components:
           type: string
           default: WEB
           example: WEB
+    ResetThrottlePolicyRequest:
+      type: object
+      required:
+        - userName
+      properties:
+        userName:
+          type: string
+          description: User name whose application throttle policy should be reset in the control plane.
+          example: alice@example.com
+      additionalProperties: false
     PlatformGatewaySubscriptionCreateRequest:
       type: object
       required:
@@ -5465,9 +5584,11 @@ components:
           type: array
           description: Optional list of API identifiers. Existing service logic synchronizes subscribed APIs for the application.
           items:
-            type: string
+            type: object
           example:
-            - api-7f4c2a6b
+            - apiName: Weather API
+              apiRefId: "214te6382jjq9274eg332190"
+              policyID: "24341d98-90f7-4530-95ef-0709609eea1a"
         tokenType:
           type: string
           enum:

--- a/docs/devportal-openapi-spec-v1.yaml
+++ b/docs/devportal-openapi-spec-v1.yaml
@@ -1,3 +1,21 @@
+#
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 openapi: 3.0.3
 info:
   title: WSO2 API Developer Portal Core - Devportal Routes

--- a/docs/devportal-openapi-spec-v1.yaml
+++ b/docs/devportal-openapi-spec-v1.yaml
@@ -1,0 +1,6550 @@
+openapi: 3.0.3
+info:
+  title: WSO2 API Developer Portal Core - Devportal Routes
+  version: 1.0.0
+  description: |
+    Fine-grained Developer Portal API for managing organizations, identity providers, providers,
+    API metadata and content, applications, subscriptions, application credentials, platform
+    gateway subscriptions, billing, invoices, usage, SDK generation, and API flows.
+
+    All paths are served under the `/devportal` base path. Operations declare the least-privilege
+    OAuth2 scopes required for each resource action, and selected billing-related endpoints also
+    support API key authentication where configured.
+servers:
+  - url: http://localhost:3000/devportal
+    description: Local development server
+  - url: https://localhost:{port}/devportal
+    description: Local HTTPS server
+    variables:
+      port:
+        default: "9443"
+tags:
+  - name: Organizations
+  - name: Identity Providers
+  - name: Organization Content
+  - name: Providers
+  - name: APIs
+  - name: API Content
+  - name: Subscription Policies
+  - name: Labels
+  - name: Applications
+  - name: Platform Subscriptions
+  - name: Platform API Keys
+  - name: Subscriptions
+  - name: App Key Mapping
+  - name: Views
+  - name: Application Keys
+  - name: SDK
+  - name: Billing
+  - name: Usage
+  - name: Invoices
+  - name: API Flows
+  - name: Utilities
+  - name: Authentication
+paths:
+  /organizations:
+    post:
+      tags:
+        - Organizations
+      summary: Create an organization
+      description: >-
+        Creates a Developer Portal organization and initializes its default portal configuration,
+        default label, default view, default WSO2 provider, and default subscription policies when
+        configured.
+      operationId: createOrganization
+      requestBody:
+        $ref: "#/components/requestBodies/OrganizationCreateBody"
+      responses:
+        "201":
+          description: Organization created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrganizationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:org_write
+            - dp:org_manage
+    get:
+      tags:
+        - Organizations
+      summary: List organizations
+      description: Returns all Developer Portal organizations visible to the admin context.
+      operationId: getOrganizations
+      responses:
+        "200":
+          $ref: "#/components/responses/OrganizationListResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:org_read
+            - dp:org_manage
+  /organizations/{orgId}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    put:
+      tags:
+        - Organizations
+      summary: Update an organization
+      description: Updates organization metadata, claim mappings, role mappings, and portal configuration.
+      operationId: updateOrganization
+      requestBody:
+        $ref: "#/components/requestBodies/OrganizationUpdateBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/OrganizationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:org_write
+            - dp:org_manage
+    get:
+      tags:
+        - Organizations
+      summary: Get an organization
+      description: >-
+        Retrieves a single organization by organization ID, organization name, organization handle, or
+        organization identifier.
+      operationId: getOrganization
+      responses:
+        "200":
+          $ref: "#/components/responses/OrganizationResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:org_read
+            - dp:org_manage
+    delete:
+      tags:
+        - Organizations
+      summary: Delete an organization
+      description: Deletes an organization and returns no response body when deletion succeeds.
+      operationId: deleteOrganization
+      responses:
+        "204":
+          description: Organization deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:org_delete
+            - dp:org_manage
+  /organizations/{orgId}/identityProvider:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Identity Providers
+      summary: Create an identity provider
+      description: Creates the organization-level OIDC identity provider configuration.
+      operationId: createIdentityProvider
+      requestBody:
+        $ref: "#/components/requestBodies/IdentityProviderBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/IdentityProviderResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:idp_write
+            - dp:idp_manage
+    put:
+      tags:
+        - Identity Providers
+      summary: Update an identity provider
+      description: Updates the organization-level OIDC identity provider configuration.
+      operationId: updateIdentityProvider
+      requestBody:
+        $ref: "#/components/requestBodies/IdentityProviderBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/IdentityProviderResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:idp_write
+            - dp:idp_manage
+    get:
+      tags:
+        - Identity Providers
+      summary: Get an identity provider
+      description: Retrieves the organization-level OIDC identity provider configuration.
+      operationId: getIdentityProvider
+      responses:
+        "200":
+          $ref: "#/components/responses/IdentityProviderResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Identity provider configuration not found.
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:idp_read
+            - dp:idp_manage
+    delete:
+      tags:
+        - Identity Providers
+      summary: Delete an identity provider
+      description: Deletes the organization-level OIDC identity provider configuration.
+      operationId: deleteIdentityProvider
+      responses:
+        "200":
+          $ref: "#/components/responses/TextMessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:idp_delete
+            - dp:idp_manage
+  /organizations/{orgId}/views/{name}/layout:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/Name"
+    post:
+      tags:
+        - Organization Content
+      summary: Upload organization layout content
+      description: >-
+        Uploads a ZIP file containing organization layout assets for the selected view. The service
+        extracts the archive, reads supported files, and stores each content item under the view.
+      operationId: createOrgContent
+      requestBody:
+        $ref: "#/components/requestBodies/FileUploadBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/OrganizationContentUploadResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:org_content_write
+            - dp:org_content_manage
+            - dp:org_manage
+    put:
+      tags:
+        - Organization Content
+      summary: Replace organization layout content
+      description: >-
+        Uploads a ZIP file and upserts the extracted organization layout assets for the selected view.
+        Existing content records are updated and missing content records are created.
+      operationId: updateOrgContent
+      requestBody:
+        $ref: "#/components/requestBodies/FileUploadBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/OrganizationContentUploadResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:org_content_write
+            - dp:org_content_manage
+            - dp:org_manage
+    get:
+      tags:
+        - Organization Content
+      summary: Get a single organization layout asset
+      description: >-
+        Retrieves one organization layout asset when `fileType` and `fileName` are supplied as query
+        parameters. The response content type is derived from the stored file type and extension.
+      operationId: getOrgLayoutContent
+      parameters:
+        - $ref: "#/components/parameters/OrgContentFileTypeQuery"
+        - $ref: "#/components/parameters/OrgContentFileNameQuery"
+        - $ref: "#/components/parameters/FilePathQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/OrganizationContentAssetResponse"
+        "400":
+          $ref: "#/components/responses/TextMessageResponse"
+        "404":
+          $ref: "#/components/responses/TextMessageResponse"
+      security:
+        - OAuth2Security:
+            - dp:org_content_read
+            - dp:org_content_manage
+            - dp:org_manage
+    delete:
+      tags:
+        - Organization Content
+      summary: Delete organization layout content
+      description: >-
+        Deletes all organization layout content for the selected view, or deletes one content item when
+        `fileName` is supplied as a query parameter.
+      operationId: deleteOrgContent
+      parameters:
+        - $ref: "#/components/parameters/FileNameQuery"
+      responses:
+        "204":
+          description: Organization content deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:org_content_delete
+            - dp:org_content_manage
+            - dp:org_manage
+  /organizations/{orgId}/views/{name}/layout/{fileType}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/Name"
+      - $ref: "#/components/parameters/FileType"
+    get:
+      tags:
+        - Organization Content
+      summary: List organization layout assets by file type
+      description: Returns all stored organization layout content records for the selected file type and view.
+      operationId: getOrgLayoutContentByFileType
+      security:
+        - OAuth2Security:
+            - dp:org_content_read
+            - dp:org_content_manage
+            - dp:org_manage
+      responses:
+        "200":
+          $ref: "#/components/responses/OrganizationContentListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/TextMessageResponse"
+  /organizations/{orgId}/provider:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Providers
+      summary: Create a provider
+      description: >-
+        Creates an API provider configuration for the organization. The current service contract accepts
+        a provider `name` and `providerURL`, rejects unexpected properties, and stores the provider URL
+        as a provider property.
+      operationId: createProvider
+      requestBody:
+        $ref: "#/components/requestBodies/ProviderBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/ProviderResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:provider_write
+            - dp:provider_manage
+    put:
+      tags:
+        - Providers
+      summary: Update a provider
+      description: Updates the provider URL for an existing organization provider.
+      operationId: updateProvider
+      requestBody:
+        $ref: "#/components/requestBodies/ProviderBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ProviderResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:provider_write
+            - dp:provider_manage
+    get:
+      tags:
+        - Providers
+      summary: Get providers
+      description: >-
+        Returns all providers for the organization. When `name` is supplied, returns the matching
+        provider configuration.
+      operationId: getProviders
+      parameters:
+        - $ref: "#/components/parameters/ProviderNameQueryOptional"
+      responses:
+        "200":
+          $ref: "#/components/responses/ProviderLookupResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:provider_read
+            - dp:provider_manage
+    delete:
+      tags:
+        - Providers
+      summary: Delete a provider
+      description: >-
+        Deletes an organization provider by `name`. When `property` is supplied, deletes only that
+        provider property.
+      operationId: deleteProvider
+      parameters:
+        - $ref: "#/components/parameters/ProviderNameQueryRequired"
+        - $ref: "#/components/parameters/ProviderPropertyQuery"
+      responses:
+        "204":
+          description: Provider or provider property deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:provider_delete
+            - dp:provider_manage
+  /organizations/{orgId}/apis:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - APIs
+      summary: Create API metadata
+      description: >-
+        Creates Developer Portal API metadata from either a full API artifact ZIP, an API metadata YAML
+        file, or an `apiMetadata` JSON string. An API definition file is required unless supplied by the
+        artifact ZIP. The service also stores labels, subscription policy mappings, image metadata, and
+        schema definitions for MCP or GraphQL APIs when provided.
+      operationId: createAPIMetadata
+      requestBody:
+        $ref: "#/components/requestBodies/ApiMetadataMultipartBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/ApiMetadataCreateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:api_write
+            - dp:api_manage
+    get:
+      tags:
+        - APIs
+      summary: List API metadata
+      description: >-
+        Lists API metadata for an organization. The service supports exact filters by API name, version,
+        and tags, free-text search with `query`, group filtering, and view filtering. Unknown query
+        parameters are rejected.
+      operationId: getAllAPIMetadataForOrganization
+      parameters:
+        - $ref: "#/components/parameters/ApiSearchQuery"
+        - $ref: "#/components/parameters/ApiNameQuery"
+        - $ref: "#/components/parameters/ApiVersionQuery"
+        - $ref: "#/components/parameters/ApiTagsQuery"
+        - $ref: "#/components/parameters/ApiGroupsQuery"
+        - $ref: "#/components/parameters/ApiViewQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApiMetadataListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:api_read
+            - dp:api_manage
+  /organizations/{orgId}/apis/{apiId}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/ApiId"
+    get:
+      tags:
+        - APIs
+      summary: Get API metadata
+      description: Retrieves a single API metadata record by Developer Portal API ID.
+      operationId: getAPIMetadata
+      responses:
+        "200":
+          $ref: "#/components/responses/ApiMetadataResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/TextMessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:api_read
+            - dp:api_manage
+    put:
+      tags:
+        - APIs
+      summary: Update API metadata
+      description: >-
+        Updates Developer Portal API metadata and its stored definition. The update flow can also adjust
+        label mappings, subscription policy mappings, schema definitions, and image metadata. Status
+        changes to unpublished are rejected when active subscriptions exist.
+      operationId: updateAPIMetadata
+      requestBody:
+        $ref: "#/components/requestBodies/ApiMetadataMultipartBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApiMetadataResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:api_write
+            - dp:api_manage
+    delete:
+      tags:
+        - APIs
+      summary: Delete API metadata
+      description: Deletes API metadata when the API has no active subscriptions.
+      operationId: deleteAPIMetadata
+      responses:
+        "200":
+          $ref: "#/components/responses/TextMessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:api_delete
+            - dp:api_manage
+  /organizations/{orgId}/subscription-policies:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Subscription Policies
+      summary: Create subscription policies
+      description: >-
+        Creates one subscription policy when the request body is an object, or multiple subscription
+        policies when the body is an array. Bulk creation returns a message instead of creating policies
+        when `generateDefaultSubPolicies` is enabled.
+      operationId: addSubscriptionPolicies
+      requestBody:
+        $ref: "#/components/requestBodies/SubscriptionPolicyBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageResponse"
+        "201":
+          $ref: "#/components/responses/SubscriptionPolicyMutationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:sub_policy_write
+            - dp:sub_policy_manage
+    put:
+      tags:
+        - Subscription Policies
+      summary: Upsert subscription policies
+      description: >-
+        Upserts one subscription policy when the request body is an object, or multiple policies when the
+        body is an array. A single policy update returns `200` when an existing policy is updated and
+        `201` when a new policy is created. Bulk updates return a message when `generateDefaultSubPolicies`
+        is enabled.
+      operationId: putSubscriptionPolicies
+      requestBody:
+        $ref: "#/components/requestBodies/SubscriptionPolicyBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionPolicyPutResponse"
+        "201":
+          $ref: "#/components/responses/SubscriptionPolicyMutationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:sub_policy_write
+            - dp:sub_policy_manage
+  /organizations/{orgId}/subscription-policies/{policyIdOrName}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/PolicyIdOrName"
+    get:
+      tags:
+        - Subscription Policies
+      summary: Get a subscription policy
+      operationId: getSubscriptionPolicy
+      description: Uses the route value as `policyID`.
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionPolicyResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:sub_policy_read
+            - dp:sub_policy_manage
+    delete:
+      tags:
+        - Subscription Policies
+      summary: Delete a subscription policy
+      operationId: deleteSubscriptionPolicy
+      description: Uses the route value as `policyName`.
+      responses:
+        "204":
+          description: Subscription policy deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:sub_policy_delete
+            - dp:sub_policy_manage
+  /organizations/{orgId}/apis/{apiId}/content:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/ApiId"
+    post:
+      tags:
+        - API Content
+      summary: Upload API content
+      description: |
+        Uploads the static content package for an API.
+
+        The `apiContent` ZIP must contain at least one of these root directories:
+        - `web/` for API landing-page assets such as markdown, HTML, CSS, JavaScript, and images.
+        - `docs/` for downloadable API documents.
+
+        Use `docMetadata` to add external document links that are stored alongside uploaded documents.
+        Use `imageMetadata` to map uploaded images to API image roles such as the API icon.
+      operationId: createAPIContent
+      requestBody:
+        $ref: "#/components/requestBodies/ApiContentZipMultipartBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:api_content_write
+            - dp:api_content_manage
+    put:
+      tags:
+        - API Content
+      summary: Replace API content
+      description: |
+        Replaces or adds static content files for an existing API.
+
+        The upload format is the same as `POST /organizations/{orgId}/apis/{apiId}/content`.
+        Existing files with the same stored `type` and `fileName` are updated; new files are created.
+        Image metadata is updated only when image metadata can be resolved from the upload or request body.
+      operationId: updateAPIContent
+      requestBody:
+        $ref: "#/components/requestBodies/ApiContentZipMultipartBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:api_content_write
+            - dp:api_content_manage
+    get:
+      tags:
+        - API Content
+      summary: Get an API content file
+      description: |
+        Retrieves a single stored API content file.
+
+        The `type` query parameter selects the stored content category and `fileName` selects the file
+        within that category. Text files and external document links are returned as text. Image files are
+        returned as binary content with a media type derived from the file extension.
+      operationId: getAPIContentFile
+      security:
+        - OAuth2Security:
+            - dp:api_content_read
+            - dp:api_content_manage
+      parameters:
+        - $ref: "#/components/parameters/ApiContentTypeQuery"
+        - $ref: "#/components/parameters/ApiContentFileNameQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/APIContentAssetResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/TextMessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - API Content
+      summary: Delete API content files
+      description: |
+        Deletes stored API content.
+
+        Send both `type` and `fileName` to delete one file. Send only `type` to delete all stored content
+        files matching that content category for the API.
+      operationId: deleteAPIContentFile
+      parameters:
+        - $ref: "#/components/parameters/ApiContentTypeQuery"
+        - $ref: "#/components/parameters/FileNameQuery"
+      responses:
+        "204":
+          description: API content deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/TextMessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:api_content_delete
+            - dp:api_content_manage
+  /organizations/{orgId}/labels:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Labels
+      summary: Create labels
+      description: Creates one or more labels for the organization. The response echoes the accepted label array.
+      operationId: createLabels
+      requestBody:
+        $ref: "#/components/requestBodies/LabelsBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/LabelsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:label_write
+            - dp:label_manage
+    put:
+      tags:
+        - Labels
+      summary: Upsert labels
+      description: >-
+        Updates existing labels by name or creates them when they do not already exist. The response
+        echoes the accepted label array.
+      operationId: updateLabel
+      requestBody:
+        $ref: "#/components/requestBodies/LabelsBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/LabelsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:label_write
+            - dp:label_manage
+    get:
+      tags:
+        - Labels
+      summary: List labels
+      description: Returns all labels configured for the organization.
+      operationId: retrieveLabels
+      responses:
+        "200":
+          $ref: "#/components/responses/LabelsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:label_read
+            - dp:label_manage
+    delete:
+      tags:
+        - Labels
+      summary: Delete labels
+      description: Deletes one or more labels by comma-separated label names.
+      operationId: deleteLabels
+      parameters:
+        - $ref: "#/components/parameters/LabelNamesQuery"
+      responses:
+        "204":
+          description: Labels deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:label_delete
+            - dp:label_manage
+  /organizations/{orgId}/applications:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Applications
+      summary: Create an application
+      description: >-
+        Creates a Developer Portal application in the specified organization for the authenticated user.
+        The request may be JSON, multipart form fields, or an application YAML file in the `application`
+        multipart field.
+      operationId: createDevPortalApplication
+      requestBody:
+        $ref: "#/components/requestBodies/ApplicationMultipartBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/ApplicationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_write
+            - dp:app_manage
+    get:
+      tags:
+        - Applications
+      summary: List applications
+      description: Returns applications in the organization that belong to the authenticated user.
+      operationId: getDevPortalApplications
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationListResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_read
+            - dp:app_manage
+  /organizations/{orgId}/applications/{appId}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/AppId"
+    put:
+      tags:
+        - Applications
+      summary: Update an application
+      description: Updates an existing Developer Portal application owned by the authenticated user.
+      operationId: updateDevPortalApplication
+      requestBody:
+        $ref: "#/components/requestBodies/ApplicationMultipartBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_write
+            - dp:app_manage
+    get:
+      tags:
+        - Applications
+      summary: Get application details
+      description: Retrieves one Developer Portal application by ID for the authenticated user.
+      operationId: getDevPortalApplicationDetails
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_read
+            - dp:app_manage
+    delete:
+      tags:
+        - Applications
+      summary: Delete an application
+      description: Deletes a Developer Portal application owned by the authenticated user.
+      operationId: deleteDevPortalApplication
+      responses:
+        "200":
+          $ref: "#/components/responses/TextMessageResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_delete
+            - dp:app_manage
+  /organizations/{orgId}/applications/import:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Applications
+      operationId: importApplications
+      summary: Import an application
+      description: >-
+        Imports an application from an application YAML file. This route is registered only when
+        `config.features.importApplication.enabled` is true. When `withKeys` is true, `keyManager` is
+        required and matching keys from the YAML are imported.
+      parameters:
+        - $ref: "#/components/parameters/PatToken"
+      requestBody:
+        $ref: "#/components/requestBodies/ImportApplicationMultipartBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationImportResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_import
+            - dp:app_manage
+  /organizations/{orgId}/api-platform-subscriptions:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Platform Subscriptions
+      operationId: createPlatformGatewaySubscription
+      summary: Create a platform gateway subscription
+      description: >-
+        Creates a token-based subscription for a Platform Gateway API. The Developer Portal API ID is
+        resolved to the control-plane API reference before the subscription is created. The API must exist,
+        have token-based subscriptions enabled, and contain a control-plane reference ID.
+      requestBody:
+        $ref: "#/components/requestBodies/PlatformGatewaySubscriptionCreateBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/PlatformGatewaySubscriptionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:platform_subscription_write
+            - dp:platform_subscription_manage
+    get:
+      tags:
+        - Platform Subscriptions
+      operationId: listPlatformGatewaySubscriptions
+      summary: List platform gateway subscriptions
+      description: >-
+        Lists platform gateway subscriptions from the control plane. When `apiId` is provided, the
+        Developer Portal API ID is validated locally and translated to the control-plane API reference.
+      parameters:
+        - $ref: "#/components/parameters/ApiIdQueryOptional"
+      responses:
+        "200":
+          $ref: "#/components/responses/PlatformGatewaySubscriptionListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:platform_subscription_read
+            - dp:platform_subscription_manage
+  /organizations/{orgId}/api-platform-subscriptions/{subscriptionId}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/SubscriptionId"
+    get:
+      tags:
+        - Platform Subscriptions
+      operationId: getPlatformGatewaySubscription
+      summary: Get a platform gateway subscription
+      description: Retrieves a single platform gateway subscription from the control plane by subscription ID.
+      responses:
+        "200":
+          $ref: "#/components/responses/PlatformGatewaySubscriptionResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:platform_subscription_read
+            - dp:platform_subscription_manage
+    put:
+      tags:
+        - Platform Subscriptions
+      operationId: updatePlatformGatewaySubscription
+      summary: Update a platform gateway subscription
+      description: Updates the subscription status in the control plane. The service accepts only `ACTIVE` or `INACTIVE`.
+      requestBody:
+        $ref: "#/components/requestBodies/PlatformGatewaySubscriptionUpdateBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/PlatformGatewaySubscriptionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:platform_subscription_write
+            - dp:platform_subscription_manage
+    delete:
+      tags:
+        - Platform Subscriptions
+      operationId: deletePlatformGatewaySubscription
+      summary: Delete a platform gateway subscription
+      description: Deletes the subscription in the control plane and returns a success message from the Developer Portal.
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:platform_subscription_delete
+            - dp:platform_subscription_manage
+  /organizations/{orgId}/platform-api-keys/generate:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Platform API Keys
+      operationId: generatePlatformApiKey
+      summary: Generate a platform API key
+      description: >-
+        Generates an API key for a Platform Gateway API. The request uses the Developer Portal API ID,
+        which is validated and resolved to the control-plane API reference before the key is generated.
+        Key names must match `^[a-z0-9][a-z0-9_-]{0,127}$`, and `expiresAt` must include a timezone when
+        sent as an ISO-8601 string.
+      requestBody:
+        $ref: "#/components/requestBodies/PlatformApiKeyBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/PlatformApiKeyGenerateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:platform_key_write
+            - dp:platform_key_manage
+  /organizations/{orgId}/platform-api-keys:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    get:
+      tags:
+        - Platform API Keys
+      operationId: listPlatformApiKeys
+      summary: List platform API keys
+      description: >-
+        Lists API keys for a Platform Gateway API. The `apiId` query parameter is required and is resolved
+        from the Developer Portal API ID to the control-plane API reference.
+      parameters:
+        - $ref: "#/components/parameters/ApiIdQueryRequired"
+      responses:
+        "200":
+          $ref: "#/components/responses/PlatformApiKeyListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:platform_key_read
+            - dp:platform_key_manage
+  /organizations/{orgId}/platform-api-keys/{apiKeyId}/regenerate:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/ApiKeyId"
+    post:
+      tags:
+        - Platform API Keys
+      operationId: regeneratePlatformApiKey
+      summary: Regenerate a platform API key
+      description: >-
+        Regenerates the secret for an existing platform API key. The request body repeats the target
+        Developer Portal API ID so the service can verify that the API exists, has a control-plane
+        reference, and is a Platform Gateway API.
+      requestBody:
+        $ref: "#/components/requestBodies/PlatformApiKeyBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/PlatformApiKeyGenerateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:platform_key_write
+            - dp:platform_key_manage
+  /organizations/{orgId}/platform-api-keys/{apiKeyId}/revoke:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/ApiKeyId"
+    post:
+      tags:
+        - Platform API Keys
+      operationId: revokePlatformApiKey
+      summary: Revoke a platform API key
+      description: >-
+        Revokes an existing platform API key for a Platform Gateway API. The Developer Portal API ID is
+        supplied as a query parameter so the service can resolve and pass the control-plane API reference.
+      parameters:
+        - $ref: "#/components/parameters/ApiIdQueryRequired"
+      responses:
+        "200":
+          $ref: "#/components/responses/EmptyResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:platform_key_revoke
+            - dp:platform_key_manage
+  /organizations/{orgId}/subscriptions:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Subscriptions
+      operationId: createSubscription
+      summary: Subscribe an application to an API
+      description: >-
+        Creates a Developer Portal subscription row and, when the application already has a control-plane
+        key mapping, creates or reconciles the corresponding control-plane subscription. If no key mapping
+        exists yet, the control-plane subscription is deferred until application keys are generated.
+      requestBody:
+        $ref: "#/components/requestBodies/SubscriptionBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionMessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:subscription_write
+            - dp:subscription_manage
+    put:
+      tags:
+        - Subscriptions
+      operationId: updateSubscription
+      summary: Update an application API subscription
+      description: >-
+        Updates the Developer Portal subscription policy and, when a control-plane subscription reference
+        exists, updates the control-plane subscription throttling policy. Canceled paid subscriptions are
+        synchronized to the control plane as blocked.
+      requestBody:
+        $ref: "#/components/requestBodies/SubscriptionBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/SubscriptionMessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:subscription_write
+            - dp:subscription_manage
+    get:
+      tags:
+        - Subscriptions
+      operationId: getAllSubscriptions
+      summary: List subscriptions
+      description: >-
+        Lists Developer Portal subscriptions for an application or API. The service filters out pending or
+        failed payment records and returns free or active paid subscriptions.
+      parameters:
+        - $ref: "#/components/parameters/AppIdQueryOptional"
+        - $ref: "#/components/parameters/ApiIdQueryOptional"
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionListResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:subscription_read
+            - dp:subscription_manage
+    delete:
+      tags:
+        - Subscriptions
+      operationId: unsubscribeAPI
+      summary: Unsubscribe an application from an API
+      description: >-
+        Removes the Developer Portal subscription identified by `subscriptionID` and deletes matching
+        control-plane subscription mappings for the supplied application and control-plane API reference.
+        If the control-plane subscription is already missing, the local subscription is still removed.
+      parameters:
+        - $ref: "#/components/parameters/AppIDQuery"
+        - $ref: "#/components/parameters/ApiReferenceIDQuery"
+        - $ref: "#/components/parameters/SubscriptionIDQuery"
+      responses:
+        "204":
+          description: Subscription removed successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:subscription_delete
+            - dp:subscription_manage
+  /organizations/{orgId}/subscriptions/{subscriptionId}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/SubscriptionId"
+    get:
+      tags:
+        - Subscriptions
+      operationId: getSubscription
+      summary: Get a subscription
+      description: Retrieves a Developer Portal subscription by subscription ID.
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:subscription_read
+            - dp:subscription_manage
+    delete:
+      tags:
+        - Subscriptions
+      operationId: deleteSubscription
+      summary: Delete a subscription
+      description: >-
+        Deletes a Developer Portal subscription by ID, removes any corresponding control-plane
+        subscriptions from application key mappings, and attempts to cancel the external Stripe
+        subscription when the local subscription is billed through Stripe.
+      responses:
+        "200":
+          $ref: "#/components/responses/TextMessageResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:subscription_delete
+            - dp:subscription_manage
+  /organizations/{orgId}/app-key-mapping:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - App Key Mapping
+      operationId: createAppKeyMapping
+      summary: Create application key mapping
+      description: >-
+        Creates or reuses a control-plane application for the Developer Portal application, synchronizes
+        existing API subscriptions into the control plane, and generates or maps credentials through the
+        selected key manager. Internal, resident, and STS key managers generate OAuth keys; external key
+        managers map the supplied `clientID` and require `tokenDetails.keyType`.
+      requestBody:
+        $ref: "#/components/requestBodies/AppKeyMappingBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/AppKeyMappingCreateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_mapping_write
+            - dp:app_key_mapping_manage
+  /organizations/{orgId}/app-key-mapping/{appId}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/AppId"
+    get:
+      tags:
+        - App Key Mapping
+      operationId: retrieveAppKeyMappings
+      summary: Get application key mappings
+      description: >-
+        Retrieves the Developer Portal application and its stored control-plane key mapping rows. The
+        request is scoped to the authenticated user, and returns `404` when the application is not visible
+        to that user.
+      responses:
+        "200":
+          $ref: "#/components/responses/AppKeyMappingListResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_mapping_read
+            - dp:app_key_mapping_manage
+  /organizations/{orgId}/views:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Views
+      operationId: addView
+      summary: Create a view
+      description: >-
+        Creates a Developer Portal view for an organization and associates it with the supplied label names.
+        If `displayName` is omitted, the service stores the view name as the display name.
+      requestBody:
+        $ref: "#/components/requestBodies/ViewCreateBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:view_write
+            - dp:view_manage
+    get:
+      tags:
+        - Views
+      operationId: getAllViews
+      summary: List views
+      description: Lists all views configured for the organization. Each view includes the label names attached to it.
+      responses:
+        "200":
+          $ref: "#/components/responses/ViewsResponse"
+        "404":
+          $ref: "#/components/responses/TextMessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:view_read
+            - dp:view_manage
+  /organizations/{orgId}/views/{name}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/Name"
+    put:
+      tags:
+        - Views
+      operationId: updateView
+      summary: Update a view
+      description: >-
+        Updates the view display name and label associations. `addedLabels` are attached to the view and
+        `removedLabels` are detached. The service returns the accepted request payload.
+      requestBody:
+        $ref: "#/components/requestBodies/ViewUpdateBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ViewUpdateEchoResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:view_write
+            - dp:view_manage
+    get:
+      tags:
+        - Views
+      operationId: getView
+      summary: Get a view
+      description: Retrieves one view by name, including the label names attached to that view.
+      responses:
+        "200":
+          $ref: "#/components/responses/ViewResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/TextMessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:view_read
+            - dp:view_manage
+    delete:
+      tags:
+        - Views
+      operationId: deleteView
+      summary: Delete a view
+      description: Deletes a view by name. A missing view is returned as a not-found error.
+      responses:
+        "204":
+          description: View deleted successfully.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:view_delete
+            - dp:view_manage
+  /applications/{applicationId}/api-keys/generate:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+    post:
+      tags:
+        - Application Keys
+      operationId: generateApplicationAPIKeys
+      summary: Generate an API key for an application API subscription
+      description: >-
+        Generates a non-shared API key for a subscribed API. If the Developer Portal application does not
+        yet have a control-plane application or subscription mapping for the API, the service creates or
+        reconciles those records first. The service resolves the production environment template through
+        the control-plane GraphQL API, defaults the key name when omitted, forwards the key generation
+        request to the control plane, and enriches the response with `appRefId`.
+      requestBody:
+        $ref: "#/components/requestBodies/ApiKeyGenerateBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationApiKeyGenerateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_write
+            - dp:app_key_manage
+  /applications/{applicationId}/generate-keys:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+    post:
+      tags:
+        - Application Keys
+      operationId: generateApplicationKeys
+      summary: Generate OAuth keys for a control-plane application
+      description: >-
+        Proxies key generation to the control-plane application key endpoint. Use this when the caller
+        already has the control-plane application ID and wants to create OAuth credentials for a key manager.
+      requestBody:
+        $ref: "#/components/requestBodies/ApplicationKeysGenerateBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationKeyResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_write
+            - dp:app_key_manage
+  /applications/{applicationId}/oauth-keys/{keyMappingId}/generate-token:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+      - $ref: "#/components/parameters/KeyMappingId"
+    post:
+      tags:
+        - Application Keys
+      operationId: generateOAuthKeys
+      summary: Generate an OAuth access token
+      description: >-
+        Proxies an access-token generation request for an existing application OAuth key mapping to the
+        control plane.
+      requestBody:
+        $ref: "#/components/requestBodies/OAuthGenerateTokenBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/OAuthTokenResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_write
+            - dp:app_key_manage
+  /applications/{applicationId}/oauth-keys/{keyMappingId}:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+      - $ref: "#/components/parameters/KeyMappingId"
+    delete:
+      tags:
+        - Application Keys
+      operationId: revokeOAuthKeys
+      summary: Revoke OAuth keys
+      description: Revokes an application OAuth key mapping in the control plane.
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageOrGenericResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_revoke
+            - dp:app_key_manage
+    put:
+      tags:
+        - Application Keys
+      operationId: updateOAuthKeys
+      summary: Update OAuth keys
+      description: Updates an application OAuth key mapping in the control plane.
+      requestBody:
+        $ref: "#/components/requestBodies/OAuthKeyUpdateBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationKeyResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_write
+            - dp:app_key_manage
+  /applications/{applicationId}/oauth-keys/{keyMappingId}/clean-up:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+      - $ref: "#/components/parameters/KeyMappingId"
+    post:
+      tags:
+        - Application Keys
+      operationId: cleanUpOAuthKeys
+      summary: Clean up OAuth key artifacts
+      description: >-
+        Proxies an OAuth key cleanup request to the control plane for a specific application key mapping.
+        This is used to remove pending or partially-created OAuth key artifacts.
+      requestBody:
+        $ref: "#/components/requestBodies/OAuthKeyCleanUpBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageOrGenericResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_write
+            - dp:app_key_manage
+  /api-keys/generate:
+    post:
+      tags:
+        - Application Keys
+      operationId: generateAPIKeys
+      summary: Generate an API key
+      description: >-
+        Generates an API key through the control plane. This root route uses the same payload and service
+        logic as the application-scoped API key generation route.
+      requestBody:
+        $ref: "#/components/requestBodies/ApiKeyGenerateBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationApiKeyGenerateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_write
+            - dp:app_key_manage
+  /api-keys/{apiKeyID}/revoke:
+    parameters:
+      - $ref: "#/components/parameters/ApiKeyID"
+    post:
+      tags:
+        - Application Keys
+      operationId: revokeAPIKeys
+      summary: Revoke an API key
+      description: Revokes an API key in the control plane.
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageOrGenericResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_revoke
+            - dp:app_key_manage
+  /api-keys/{apiKeyID}/regenerate:
+    parameters:
+      - $ref: "#/components/parameters/ApiKeyID"
+    post:
+      tags:
+        - Application Keys
+      operationId: regenerateAPIKeys
+      summary: Regenerate an API key
+      description: Regenerates an existing API key in the control plane and returns the regenerated key payload.
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationApiKeyGenerateResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:app_key_write
+            - dp:app_key_manage
+  /applications/{applicationId}/generate-sdk:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+    post:
+      tags:
+        - SDK
+      operationId: generateSDK
+      requestBody:
+        $ref: "#/components/requestBodies/SDKGenerateBody"
+      responses:
+        default:
+          $ref: "#/components/responses/DefaultResponse"
+      security:
+        - OAuth2Security:
+            - dp:sdk_generate
+            - dp:sdk_manage
+  /applications/{applicationId}/sdk/job-progress/{jobId}:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+      - $ref: "#/components/parameters/JobId"
+    get:
+      tags:
+        - SDK
+      operationId: streamSDKProgress
+      responses:
+        default:
+          description: Server-sent event stream or JSON response.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericObject"
+      security:
+        - OAuth2Security:
+            - dp:sdk_read
+            - dp:sdk_manage
+  /applications/{applicationId}/sdk/cancel/{jobId}:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationId"
+      - $ref: "#/components/parameters/JobId"
+    post:
+      tags:
+        - SDK
+      operationId: cancelSDK
+      responses:
+        default:
+          $ref: "#/components/responses/DefaultResponse"
+      security:
+        - OAuth2Security:
+            - dp:sdk_cancel
+            - dp:sdk_manage
+  /sdk/download/{filename}:
+    parameters:
+      - $ref: "#/components/parameters/Filename"
+    get:
+      tags:
+        - SDK
+      operationId: downloadSDK
+      responses:
+        default:
+          $ref: "#/components/responses/BinaryOrJsonResponse"
+      security:
+        - OAuth2Security:
+            - dp:sdk:read
+  /organizations/{orgId}/billing/usage-data:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    get:
+      tags:
+        - Billing
+      operationId: getUsageData
+      summary: Get billing usage data
+      description: >-
+        Returns billing usage totals for the authenticated user in the organization. The optional period
+        can be `current`, `last30`, or `last90`; `from` and `to` can be used for a custom date range.
+      parameters:
+        - $ref: "#/components/parameters/BillingUsagePeriodQuery"
+        - $ref: "#/components/parameters/BillingUsageFromQuery"
+        - $ref: "#/components/parameters/BillingUsageToQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/BillingUsageDataResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_read
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/billing/payment-methods:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    get:
+      tags:
+        - Billing
+      operationId: getPaymentMethods
+      summary: List payment methods
+      description: >-
+        Lists Stripe payment methods for the authenticated billing user. If no Stripe customer exists yet,
+        the service can create or locate one by user email before listing methods.
+      responses:
+        "200":
+          $ref: "#/components/responses/PaymentMethodsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_read
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/billing-engine-keys:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Billing
+      operationId: addBillingEngineKeys
+      summary: Add billing engine keys
+      description: >-
+        Stores encrypted billing engine credentials for the organization. Currently used for Stripe
+        secret, publishable, and webhook keys.
+      requestBody:
+        $ref: "#/components/requestBodies/BillingEngineKeysBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_config_write
+            - dp:billing_config_manage
+    put:
+      tags:
+        - Billing
+      operationId: updateBillingEngineKeys
+      summary: Update billing engine keys
+      description: Updates the encrypted billing engine credentials for an existing organization billing configuration.
+      requestBody:
+        $ref: "#/components/requestBodies/BillingEngineKeysBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_config_write
+            - dp:billing_config_manage
+    delete:
+      tags:
+        - Billing
+      operationId: deleteBillingEngineKeys
+      summary: Delete billing engine keys
+      description: >-
+        Deletes billing engine credentials for the organization. `billingEngine` may be supplied in the
+        request body or as a query parameter.
+      requestBody:
+        $ref: "#/components/requestBodies/BillingEngineDeleteBody"
+      parameters:
+        - $ref: "#/components/parameters/BillingEngineQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_config_delete
+            - dp:billing_config_manage
+    get:
+      tags:
+        - Billing
+      operationId: getBillingEngineKeys
+      summary: Get billing engine keys
+      description: >-
+        Returns masked billing engine key metadata. Secret values are never returned; configured values are
+        represented as `****`.
+      parameters:
+        - $ref: "#/components/parameters/BillingEngineQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/BillingEngineKeysResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_config_read
+            - dp:billing_config_manage
+  /organizations/{orgId}/billing/info:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    get:
+      tags:
+        - Billing
+      operationId: getBillingInfo
+      summary: Get billing profile information
+      description: >-
+        Returns billing profile information for the authenticated user and organization. When a Stripe
+        customer exists, the response includes customer address and tax ID information from Stripe.
+      responses:
+        "200":
+          $ref: "#/components/responses/BillingInfoResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_read
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/billing/subscriptions:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    get:
+      tags:
+        - Billing
+      operationId: getActiveSubscriptions
+      summary: List subscriptions for billing
+      description: >-
+        Returns the authenticated user's subscriptions formatted for the billing page, including plan,
+        billing cycle, amount, currency, next billing date, and payment status.
+      responses:
+        "200":
+          $ref: "#/components/responses/BillingSubscriptionsResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_read
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/monetization/checkout:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Billing
+      operationId: createCheckoutSessionForSubscription
+      summary: Create a checkout session
+      description: >-
+        Creates a pending Developer Portal subscription row and a Stripe embedded checkout session for a
+        paid subscription policy.
+      requestBody:
+        $ref: "#/components/requestBodies/CheckoutSessionBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/CheckoutSessionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/MessageResponse"
+        "502":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_write
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/monetization/stripe/register/{checkoutSessionId}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/CheckoutSessionId"
+    post:
+      tags:
+        - Billing
+      operationId: registerStripeCheckoutSession
+      summary: Register a Stripe checkout session
+      description: >-
+        Verifies the Stripe checkout session, activates the Developer Portal subscription, and synchronizes
+        the subscription into the control plane when application key mappings already exist.
+      responses:
+        "201":
+          $ref: "#/components/responses/CheckoutRegistrationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/MessageResponse"
+        "502":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_write
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/subscriptions/{subId}/cancel:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/SubId"
+    post:
+      tags:
+        - Billing
+      operationId: cancelSubscription
+      summary: Cancel a paid subscription
+      description: >-
+        Cancels a paid Stripe subscription, marks the Developer Portal subscription as canceled, and
+        schedules non-fatal Moesif billing cleanup.
+      responses:
+        "200":
+          $ref: "#/components/responses/BillingCancelResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "502":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_write
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/subscriptions/{subId}/billing-status:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/SubId"
+    get:
+      tags:
+        - Billing
+      operationId: getSubscriptionBillingStatus
+      summary: Get subscription billing status
+      description: Returns billing status and Stripe billing identifiers for a Developer Portal subscription.
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionBillingStatusResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_read
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/billing-portal:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    post:
+      tags:
+        - Billing
+      operationId: createBillingPortalByOrg
+      summary: Create an organization billing portal session
+      description: >-
+        Creates a Stripe customer portal session for the authenticated user's organization. If no billed
+        subscription exists yet, the service can create or locate a Stripe customer by user email.
+      responses:
+        "200":
+          $ref: "#/components/responses/BillingPortalResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "502":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_write
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/subscriptions/{subId}/billing-portal:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/SubId"
+    post:
+      tags:
+        - Billing
+      operationId: createBillingPortal
+      summary: Create a subscription billing portal session
+      description: Creates a Stripe customer portal session for a specific paid subscription.
+      responses:
+        "200":
+          $ref: "#/components/responses/BillingPortalResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "502":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:billing_write
+            - dp:billing_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/subscriptions/{subId}/usage:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/SubId"
+    get:
+      tags:
+        - Usage
+      operationId: getSubscriptionUsage
+      summary: Get subscription usage
+      description: >-
+        Returns usage metrics for a subscription over a date range. When `usageFrom` or `usageTo` are not
+        supplied, the service defaults to the last 30 days ending at the current time.
+      parameters:
+        - $ref: "#/components/parameters/UsageFromQuery"
+        - $ref: "#/components/parameters/UsageToQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionUsageResponse"
+        "400":
+          $ref: "#/components/responses/UsageErrorResponse"
+        "404":
+          $ref: "#/components/responses/UsageErrorResponse"
+        "502":
+          $ref: "#/components/responses/UsageErrorResponse"
+        "500":
+          $ref: "#/components/responses/UsageErrorResponse"
+      security:
+        - OAuth2Security:
+            - dp:usage_read
+            - dp:usage_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/invoices:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+    get:
+      tags:
+        - Invoices
+      operationId: listInvoices
+      summary: List invoices
+      description: >-
+        Lists invoices for the authenticated billing user. The `period` query controls the Stripe invoice
+        created-date window.
+      parameters:
+        - $ref: "#/components/parameters/InvoicePeriodQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/InvoiceListResponse"
+        "400":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "502":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "500":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+      security:
+        - OAuth2Security:
+            - dp:invoice_read
+            - dp:invoice_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/invoices/{invoiceId}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/InvoiceId"
+    get:
+      tags:
+        - Invoices
+      operationId: getInvoice
+      summary: Get an invoice
+      description: Retrieves a Stripe invoice after verifying that the invoice customer belongs to the authenticated user.
+      responses:
+        "200":
+          $ref: "#/components/responses/InvoiceResponse"
+        "400":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "404":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "502":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "500":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+      security:
+        - OAuth2Security:
+            - dp:invoice_read
+            - dp:invoice_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/subscriptions/{subId}/invoices:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/SubId"
+    get:
+      tags:
+        - Invoices
+      operationId: listInvoicesBySubscription
+      summary: List invoices by subscription
+      description: >-
+        Lists Stripe invoices for a specific Developer Portal subscription after verifying subscription
+        ownership. The response preserves Stripe's invoice list shape and filters it to the Stripe
+        subscription linked to the Developer Portal subscription.
+      responses:
+        "200":
+          $ref: "#/components/responses/StripeInvoiceListResponse"
+        "400":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "404":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "502":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "500":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+      security:
+        - OAuth2Security:
+            - dp:invoice_read
+            - dp:invoice_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/invoices/{invoiceId}/pdf:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/InvoiceId"
+    get:
+      tags:
+        - Invoices
+      operationId: getInvoicePdfLink
+      summary: Get invoice PDF link
+      description: Returns hosted invoice and PDF links for an invoice. A non-finalized invoice may not have a PDF link yet.
+      responses:
+        "200":
+          $ref: "#/components/responses/InvoicePdfLinkResponse"
+        "404":
+          $ref: "#/components/responses/InvoicePdfNotAvailableResponse"
+        "400":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "502":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "500":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+      security:
+        - OAuth2Security:
+            - dp:invoice_read
+            - dp:invoice_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/invoices/{invoiceId}/hosted:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/InvoiceId"
+    get:
+      tags:
+        - Invoices
+      operationId: redirectHostedInvoice
+      responses:
+        "302":
+          description: Redirects to the hosted invoice URL.
+          headers:
+            Location:
+              description: Hosted Stripe invoice URL.
+              schema:
+                type: string
+                format: uri
+        "404":
+          $ref: "#/components/responses/MessageResponse"
+        "400":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "502":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+        "500":
+          $ref: "#/components/responses/InvoiceErrorResponse"
+      security:
+        - OAuth2Security:
+            - dp:invoice_read
+            - dp:invoice_manage
+        - apiKeyAuth: []
+  /organizations/{orgId}/views/{viewName}/api-flows:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/ViewName"
+    post:
+      tags:
+        - API Flows
+      operationId: createAPIFlow
+      summary: Create an API flow
+      description: >-
+        Creates an API flow in the selected view. If `handle` is omitted, the service generates one from
+        the name. `ARAZZO` content is parsed from JSON or YAML; invalid Arazzo content returns a bad request.
+      requestBody:
+        $ref: "#/components/requestBodies/APIFlowCreateBody"
+      responses:
+        "201":
+          $ref: "#/components/responses/APIFlowCreateResponse"
+        "400":
+          $ref: "#/components/responses/MessageResponse"
+        "409":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/MessageResponse"
+      security:
+        - OAuth2Security:
+            - dp:api_flow_write
+            - dp:api_flow_manage
+    get:
+      tags:
+        - API Flows
+      operationId: getAllAPIFlows
+      summary: List API flows
+      description: Lists all API flows for the selected organization view.
+      responses:
+        "200":
+          $ref: "#/components/responses/APIFlowListResponse"
+        "500":
+          $ref: "#/components/responses/MessageResponse"
+      security:
+        - OAuth2Security:
+            - dp:api_flow_read
+            - dp:api_flow_manage
+  /organizations/{orgId}/views/{viewName}/api-flows/{apiFlowId}:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/ViewName"
+      - $ref: "#/components/parameters/ApiFlowId"
+    get:
+      tags:
+        - API Flows
+      operationId: getAPIFlow
+      summary: Get an API flow
+      description: Retrieves a single API flow by ID from the selected view.
+      responses:
+        "200":
+          $ref: "#/components/responses/APIFlowResponse"
+        "404":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/MessageResponse"
+      security:
+        - OAuth2Security:
+            - dp:api_flow_read
+            - dp:api_flow_manage
+    put:
+      tags:
+        - API Flows
+      operationId: updateAPIFlow
+      summary: Update an API flow
+      description: Updates API flow metadata and content for the selected view. Duplicate handles return a conflict.
+      requestBody:
+        $ref: "#/components/requestBodies/APIFlowUpdateBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageResponse"
+        "400":
+          $ref: "#/components/responses/MessageResponse"
+        "404":
+          $ref: "#/components/responses/MessageResponse"
+        "409":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/MessageResponse"
+      security:
+        - OAuth2Security:
+            - dp:api_flow_write
+            - dp:api_flow_manage
+    delete:
+      tags:
+        - API Flows
+      operationId: deleteAPIFlow
+      summary: Delete an API flow
+      description: Deletes an API flow from the selected view.
+      responses:
+        "200":
+          $ref: "#/components/responses/MessageResponse"
+        "404":
+          $ref: "#/components/responses/MessageResponse"
+        "500":
+          $ref: "#/components/responses/MessageResponse"
+      security:
+        - OAuth2Security:
+            - dp:api_flow_delete
+            - dp:api_flow_manage
+  /organizations/{orgId}/views/{viewName}/api-flows/generate-prompt:
+    parameters:
+      - $ref: "#/components/parameters/OrgId"
+      - $ref: "#/components/parameters/ViewName"
+    post:
+      tags:
+        - API Flows
+      operationId: generatePrompt
+      summary: Generate an API flow agent prompt
+      description: Generates the default agent prompt text for a proposed API flow using the supplied name, description, APIs, and view context.
+      requestBody:
+        $ref: "#/components/requestBodies/APIFlowPromptBody"
+      responses:
+        "200":
+          $ref: "#/components/responses/APIFlowPromptResponse"
+        "500":
+          $ref: "#/components/responses/MessageResponse"
+      security:
+        - OAuth2Security:
+            - dp:api_flow_write
+            - dp:api_flow_manage
+  /temp-arazzo-file:
+    post:
+      tags:
+        - Utilities
+      operationId: createTempArazzoFile
+      summary: Create a temporary Arazzo file
+      description: Writes supplied Arazzo YAML content to a temporary file and returns its path.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TempArazzoFileRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/TempArazzoFileResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - OAuth2Security:
+            - dp:utility_write
+            - dp:utility_manage
+  /login:
+    post:
+      tags:
+        - Authentication
+      operationId: login
+      security: []
+      requestBody:
+        $ref: "#/components/requestBodies/LoginBody"
+      responses:
+        default:
+          $ref: "#/components/responses/DefaultResponse"
+components:
+  securitySchemes:
+    OAuth2Security:
+      type: oauth2
+      description: >-
+        OAuth2/OIDC access token with fine-grained Developer Portal scopes. Each operation declares the exact
+        resource/action scope it requires.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://localhost:9443/oauth2/authorize
+          tokenUrl: https://localhost:9443/oauth2/token
+          scopes:
+            dp:org_read: Read organizations.
+            dp:org_write: Create or update organizations.
+            dp:org_delete: Delete organizations.
+            dp:org_manage: Manage organizations (including creating, updating, and deleting).
+            dp:idp_read: Read organization identity provider configuration.
+            dp:idp_write: Create or update identity provider configuration.
+            dp:idp_delete: Delete identity provider configuration.
+            dp:idp_manage: Manage organization identity provider configuration.
+            dp:provider_read: Read providers.
+            dp:provider_write: Create or update providers.
+            dp:provider_delete: Delete providers.
+            dp:provider_manage: Manage providers (including creating, updating, and deleting).
+            dp:org_content_read: Read organization layout or content.
+            dp:org_content_write: Create or update organization layout or content.
+            dp:org_content_delete: Delete organization layout or content.
+            dp:org_content_manage: Manage organization layout or content.
+            dp:api_read: Read API metadata.
+            dp:api_write: Create or update API metadata.
+            dp:api_delete: Delete API metadata.
+            dp:api_manage: Manage API metadata.
+            dp:api_content_read: Read API content.
+            dp:api_content_write: Create or update API content.
+            dp:api_content_delete: Delete API content.
+            dp:api_content_manage: Manage API content.
+            dp:sub_policy_read: Read subscription policies.
+            dp:sub_policy_write: Create or update subscription policies.
+            dp:sub_policy_delete: Delete subscription policies.
+            dp:sub_policy_manage: Manage subscription policies.
+            dp:label_read: Read labels.
+            dp:label_write: Create or update labels.
+            dp:label_delete: Delete labels.
+            dp:label_manage: Manage labels.
+            dp:app_read: Read applications.
+            dp:app_write: Create or update applications.
+            dp:app_delete: Delete applications.
+            dp:app_import: Import applications.
+            dp:app_manage: Manage applications.
+            dp:platform_subscription_read: Read platform gateway subscriptions.
+            dp:platform_subscription_write: Create or update platform gateway subscriptions.
+            dp:platform_subscription_delete: Delete platform gateway subscriptions.
+            dp:platform_subscription_manage: Manage platform gateway subscriptions.
+            dp:platform_key_read: Read platform API keys.
+            dp:platform_key_write: Generate or regenerate platform API keys.
+            dp:platform_key_revoke: Revoke platform API keys.
+            dp:platform_key_manage: Manage platform API keys.
+            dp:subscription_read: Read subscriptions.
+            dp:subscription_write: Create or update subscriptions.
+            dp:subscription_delete: Delete or unsubscribe subscriptions.
+            dp:subscription_manage: Manage subscriptions.
+            dp:app_key_mapping_read: Read application key mappings.
+            dp:app_key_mapping_write: Create application key mappings.
+            dp:app_key_mapping_manage: Manage application key mappings.
+            dp:view_read: Read views.
+            dp:view_write: Create or update views.
+            dp:view_delete: Delete views.
+            dp:view_manage: Manage views.
+            dp:app_key_write: Generate, update, regenerate, or clean up application keys.
+            dp:app_key_revoke: Revoke application keys.
+            dp:app_key_manage: Manage application keys.
+            dp:sdk_generate: Generate SDKs.
+            dp:sdk_read: Read SDK generation progress or download SDKs.
+            dp:sdk_cancel: Cancel SDK generation jobs.
+            dp:sdk_manage: Manage SDK generation.
+            dp:billing_read: Read billing information, usage data, payment methods, and subscription billing status.
+            dp:billing_write: >-
+              Create checkout sessions, register checkout sessions, create billing portal sessions, or cancel paid
+              subscriptions.
+            dp:billing_manage: Manage billing information, checkout, portal, and subscription billing actions.
+            dp:billing_config_read: Read billing engine key configuration.
+            dp:billing_config_write: Create or update billing engine key configuration.
+            dp:billing_config_delete: Delete billing engine key configuration.
+            dp:billing_config_manage: Manage billing engine key configuration.
+            dp:usage_read: Read subscription usage.
+            dp:usage_manage: Manage subscription usage access.
+            dp:invoice_read: Read invoices and invoice links.
+            dp:invoice_manage: Manage invoice access.
+            dp:api_flow_read: Read API flows.
+            dp:api_flow_write: Create, update, or generate API flows.
+            dp:api_flow_delete: Delete API flows.
+            dp:api_flow_manage: Manage API flows.
+            dp:utility_write: Create temporary utility files.
+            dp:utility_manage: Manage utility operations.
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+      description: >-
+        API key authentication. Server-side authorization should bind each key to the same fine-grained permissions used
+        by OAuth2 scopes.
+  parameters:
+    OrgId:
+      name: orgId
+      in: path
+      required: true
+      schema:
+        type: string
+    Name:
+      name: name
+      in: path
+      required: true
+      schema:
+        type: string
+    FileType:
+      name: fileType
+      in: path
+      required: true
+      schema:
+        type: string
+    ApiId:
+      name: apiId
+      in: path
+      required: true
+      schema:
+        type: string
+        example: api-7f4c2a6b
+    PolicyIdOrName:
+      name: policyIdOrName
+      in: path
+      required: true
+      schema:
+        type: string
+    AppId:
+      name: appId
+      in: path
+      required: true
+      schema:
+        type: string
+        example: app-12345
+    SubscriptionId:
+      name: subscriptionId
+      in: path
+      required: true
+      schema:
+        type: string
+    SubId:
+      name: subId
+      in: path
+      required: true
+      schema:
+        type: string
+    ApiKeyId:
+      name: apiKeyId
+      in: path
+      required: true
+      schema:
+        type: string
+    ApplicationId:
+      name: applicationId
+      in: path
+      required: true
+      schema:
+        type: string
+        example: app-12345
+    KeyMappingId:
+      name: keyMappingId
+      in: path
+      required: true
+      schema:
+        type: string
+    ApiKeyID:
+      name: apiKeyID
+      in: path
+      required: true
+      schema:
+        type: string
+    JobId:
+      name: jobId
+      in: path
+      required: true
+      schema:
+        type: string
+    Filename:
+      name: filename
+      in: path
+      required: true
+      schema:
+        type: string
+    CheckoutSessionId:
+      name: checkoutSessionId
+      in: path
+      required: true
+      schema:
+        type: string
+    InvoiceId:
+      name: invoiceId
+      in: path
+      required: true
+      schema:
+        type: string
+        example: in_12345
+    ViewName:
+      name: viewName
+      in: path
+      required: true
+      schema:
+        type: string
+        example: default
+    ApiFlowId:
+      name: apiFlowId
+      in: path
+      required: true
+      schema:
+        type: string
+        example: flow-12345
+    UsageFromQuery:
+      name: usageFrom
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date-time
+        example: "2026-04-07T00:00:00Z"
+      description: Usage start timestamp. Defaults to 30 days before the request time.
+    UsageToQuery:
+      name: usageTo
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date-time
+        example: "2026-05-07T00:00:00Z"
+      description: Usage end timestamp. Defaults to the request time.
+    InvoicePeriodQuery:
+      name: period
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - last3months
+          - last6months
+          - last12months
+          - all
+        default: last3months
+      description: Invoice created-date window.
+    ContentTypeQuery:
+      name: type
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Content type selector used by API file retrieval.
+    ApiContentTypeQuery:
+      name: type
+      in: query
+      required: true
+      schema:
+        type: string
+        example: document
+      description: >-
+        Stored API content type selector. Common values are `web`, `document`, `image`, and `link`,
+        depending on how the uploaded ZIP content was classified.
+    ApiContentFileNameQuery:
+      name: fileName
+      in: query
+      required: true
+      schema:
+        type: string
+        example: getting-started.md
+      description: Stored API content file name to retrieve.
+    FileNameQuery:
+      name: fileName
+      in: query
+      required: false
+      schema:
+        type: string
+        example: getting-started.md
+      description: File name selector used by file retrieval and organization content deletion.
+    OrgContentFileNameQuery:
+      name: fileName
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Stored organization content file name.
+    OrgContentFileTypeQuery:
+      name: fileType
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Organization content file type, such as style, image, text, template, or partial.
+    FilePathQuery:
+      name: filePath
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Optional relative content path used together with `fileType` and `fileName`.
+    ProviderNameQueryOptional:
+      name: name
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Optional provider name selector. When omitted, all providers are returned.
+    ProviderNameQueryRequired:
+      name: name
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Provider name.
+    ProviderPropertyQuery:
+      name: property
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Optional provider property name to delete instead of deleting the whole provider.
+    ApiSearchQuery:
+      name: query
+      in: query
+      required: false
+      schema:
+        type: string
+        example: weather
+      description: Free-text API metadata search term.
+    ApiNameQuery:
+      name: apiName
+      in: query
+      required: false
+      schema:
+        type: string
+        example: Weather API
+      description: Exact API name filter.
+    ApiVersionQuery:
+      name: version
+      in: query
+      required: false
+      schema:
+        type: string
+        example: v1
+      description: Exact API version filter.
+    ApiTagsQuery:
+      name: tags
+      in: query
+      required: false
+      schema:
+        type: string
+        example: weather public
+      description: Exact API tags filter used by the metadata DAO.
+    ApiGroupsQuery:
+      name: groups
+      in: query
+      required: false
+      schema:
+        type: string
+        example: subscriber admin
+      description: Space-separated visible groups used for API visibility filtering.
+    ApiViewQuery:
+      name: view
+      in: query
+      required: false
+      schema:
+        type: string
+        example: default
+      description: Developer Portal view name used to filter visible APIs.
+    ApiIdQueryRequired:
+      name: apiId
+      in: query
+      required: true
+      schema:
+        type: string
+        example: api-7f4c2a6b
+      description: Developer Portal API ID used to resolve the control-plane API reference.
+    ApiIdQueryOptional:
+      name: apiId
+      in: query
+      required: false
+      schema:
+        type: string
+        example: api-7f4c2a6b
+      description: Optional Developer Portal API ID used to filter by the resolved control-plane API reference.
+    PatToken:
+      name: pat-token
+      in: header
+      required: true
+      schema:
+        type: string
+      description: Personal access token used by the application import flow.
+    LabelNamesQuery:
+      name: names
+      in: query
+      required: true
+      schema:
+        type: string
+        example: default,premium
+      description: Comma-separated label names to delete.
+    AppIDQuery:
+      name: appID
+      in: query
+      required: true
+      schema:
+        type: string
+        example: app-12345
+      description: Developer Portal application ID.
+    AppIdQueryOptional:
+      name: appId
+      in: query
+      required: false
+      schema:
+        type: string
+        example: app-12345
+      description: Optional Developer Portal application ID used to filter subscriptions.
+    ApiReferenceIDQuery:
+      name: apiReferenceID
+      in: query
+      required: true
+      schema:
+        type: string
+        example: cp-api-12345
+      description: Control-plane API reference ID used to remove matching application key mappings.
+    SubscriptionIDQuery:
+      name: subscriptionID
+      in: query
+      required: true
+      schema:
+        type: string
+        example: sub-12345
+      description: Developer Portal subscription ID to remove.
+    BillingEngineQuery:
+      name: billingEngine
+      in: query
+      required: false
+      schema:
+        type: string
+        example: STRIPE
+      description: Alternative to sending `billingEngine` in the delete request body.
+    BillingUsagePeriodQuery:
+      name: period
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - current
+          - last30
+          - last90
+        default: current
+      description: Usage period used when `from` and `to` are not supplied.
+    BillingUsageFromQuery:
+      name: from
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date
+        example: "2026-05-01"
+      description: Custom usage start date. The service expands this to the beginning of the day in UTC.
+    BillingUsageToQuery:
+      name: to
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date
+        example: "2026-05-07"
+      description: Custom usage end date. The service expands this to the end of the day in UTC.
+  requestBodies:
+    JsonObjectBody:
+      required: false
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericObject"
+    OrganizationCreateBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OrganizationCreateRequest"
+          example:
+            orgName: Acme Corporation
+            businessOwner: Jane Doe
+            businessOwnerContact: +1-202-555-0147
+            businessOwnerEmail: jane.doe@acme.example
+            orgHandle: acme
+            roleClaimName: roles
+            groupsClaimName: groups
+            organizationClaimName: organizationIdentifier
+            organizationIdentifier: ACME
+            adminRole: admin
+            subscriberRole: subscriber
+            superAdminRole: superAdmin
+    OrganizationUpdateBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OrganizationUpdateRequest"
+    IdentityProviderBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/IdentityProviderRequest"
+    ProviderBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProviderRequest"
+    SubscriptionPolicyBody:
+      required: true
+      description: >-
+        Subscription policy payload. Send a single object for single create/upsert, or a non-empty array
+        for bulk create/upsert. The service currently processes policies with `type` set to
+        `requestcount` or `eventcount`.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/SubscriptionPolicyRequest"
+              - type: array
+                minItems: 1
+                items:
+                  $ref: "#/components/schemas/SubscriptionPolicyRequest"
+    LabelsBody:
+      required: true
+      description: Label array to create or upsert.
+      content:
+        application/json:
+          schema:
+            type: array
+            minItems: 1
+            items:
+              $ref: "#/components/schemas/LabelRequest"
+          example:
+            - name: premium
+              displayName: Premium APIs
+            - name: internal
+              displayName: Internal APIs
+    PlatformGatewaySubscriptionCreateBody:
+      required: true
+      description: >-
+        Subscription creation payload. `apiId` is the Developer Portal API ID; the service resolves it to
+        the control-plane API reference before forwarding the request.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PlatformGatewaySubscriptionCreateRequest"
+          examples:
+            defaultPlan:
+              summary: Subscribe with the API default plan
+              value:
+                apiId: api-7f4c2a6b
+            selectedPlanAndApplication:
+              summary: Subscribe using a specific plan and control-plane application
+              value:
+                apiId: api-7f4c2a6b
+                subscriptionPlanName: Gold
+                applicationId: cp-app-98765
+    PlatformGatewaySubscriptionUpdateBody:
+      required: true
+      description: Platform gateway subscription status update payload.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PlatformGatewaySubscriptionUpdateRequest"
+          example:
+            status: ACTIVE
+    PlatformApiKeyBody:
+      required: true
+      description: >-
+        Platform API key payload. `apiId` is the Developer Portal API ID. `name` must be lowercase and may
+        contain numbers, underscores, and hyphens. `expiresAt` can be an ISO-8601 datetime with timezone,
+        epoch seconds, or epoch milliseconds.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PlatformApiKeyRequest"
+          examples:
+            expiringKey:
+              summary: Generate an expiring key
+              value:
+                apiId: api-7f4c2a6b
+                name: weather_prod_key
+                expiresAt: "2026-12-31T23:59:59Z"
+            nonExpiringKey:
+              summary: Generate a key without expiry
+              value:
+                apiId: api-7f4c2a6b
+                name: weather_sandbox_key
+    SubscriptionBody:
+      required: true
+      description: >-
+        Subscription payload. `apiId` and `policyId` are Developer Portal identifiers; `apiReferenceID`
+        and `policyName` are used when the service synchronizes the subscription with the control plane.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SubscriptionRequest"
+          examples:
+            freePlan:
+              summary: Subscribe using a free policy
+              value:
+                applicationID: app-12345
+                apiId: api-7f4c2a6b
+                apiReferenceID: cp-api-12345
+                policyId: policy-gold
+                policyName: Gold
+            updatePlan:
+              summary: Change subscription policy
+              value:
+                applicationID: app-12345
+                apiId: api-7f4c2a6b
+                apiReferenceID: cp-api-12345
+                policyId: policy-silver
+                policyName: Silver
+    AppKeyMappingBody:
+      required: true
+      description: >-
+        Application key mapping payload. Use internal, resident, or STS key managers to generate OAuth
+        keys. For external key managers, provide `clientID` and `tokenDetails.keyType` to map an existing
+        client.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AppKeyMappingRequest"
+          examples:
+            generateResidentOAuthKeys:
+              summary: Generate OAuth keys using the resident key manager
+              value:
+                applicationName: Weather App
+                tokenType: OAUTH
+                tokenDetails:
+                  keyManager: Resident Key Manager
+                  keyType: PRODUCTION
+                  grantTypesToBeSupported:
+                    - client_credentials
+                    - refresh_token
+                  callbackUrl: https://app.example.com/callback
+                  additionalProperties:
+                    application_access_token_expiry_time: "3600"
+                    user_access_token_expiry_time: "3600"
+            mapExternalClient:
+              summary: Map an existing external client ID
+              value:
+                applicationName: Weather App
+                tokenType: OAUTH
+                clientID: external-client-123
+                tokenDetails:
+                  keyManager: External Key Manager
+                  keyType: PRODUCTION
+    ViewCreateBody:
+      required: true
+      description: View creation payload with the label names that should be visible in the view.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ViewCreateRequest"
+          examples:
+            partnerView:
+              summary: Create a partner APIs view
+              value:
+                name: partner-apis
+                displayName: Partner APIs
+                labels:
+                  - partner
+                  - public
+            internalView:
+              summary: Create a view using the name as display name
+              value:
+                name: internal-apis
+                labels:
+                  - internal
+    ViewUpdateBody:
+      required: true
+      description: View update payload. Include only the display-name or label changes that should be applied.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ViewUpdateRequest"
+          examples:
+            renameAndRelabel:
+              summary: Rename a view and adjust labels
+              value:
+                displayName: Partner and Public APIs
+                addedLabels:
+                  - premium
+                removedLabels:
+                  - internal
+            addLabelsOnly:
+              summary: Add labels without renaming
+              value:
+                addedLabels:
+                  - beta
+    ApiKeyGenerateBody:
+      required: true
+      description: >-
+        API key generation payload. `apiId` is the control-plane API reference ID, while `devportalAppId`
+        is the Developer Portal application ID. `projectID` is used to resolve the production environment
+        template before the request is sent to the control plane.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiKeyGenerateRequest"
+          examples:
+            productionKey:
+              summary: Generate a production API key
+              value:
+                apiId: cp-api-12345
+                devportalAppId: app-12345
+                applicationId: cp-app-98765
+                projectID: project-12345
+                keyType: PRODUCTION
+                name: weather-prod-key
+                subscriptionPlan:
+                  policyName: Gold
+            sandboxKey:
+              summary: Generate a sandbox API key
+              value:
+                apiId: cp-api-12345
+                devportalAppId: app-12345
+                projectID: project-12345
+                keyType: SANDBOX
+                subscriptionPlan: Gold
+    ApplicationKeysGenerateBody:
+      required: false
+      description: OAuth key generation payload passed through to the configured control-plane application key endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApplicationKeysGenerateRequest"
+          example:
+            keyType: PRODUCTION
+            keyManager: Resident Key Manager
+            grantTypesToBeSupported:
+              - client_credentials
+              - refresh_token
+            callbackUrl: https://app.example.com/callback
+            additionalProperties:
+              application_access_token_expiry_time: 3600
+    OAuthGenerateTokenBody:
+      required: false
+      description: Passed through to the configured control-plane OAuth token generation endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OAuthGenerateTokenRequest"
+          example:
+            scopes:
+              - weather.read
+            validityPeriod: 3600
+    OAuthKeyUpdateBody:
+      required: false
+      description: Passed through to the configured control-plane OAuth key update endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OAuthKeyUpdateRequest"
+          example:
+            supportedGrantTypes:
+              - client_credentials
+              - refresh_token
+            callbackUrl: https://app.example.com/new-callback
+            additionalProperties:
+              application_access_token_expiry_time: 7200
+    OAuthKeyCleanUpBody:
+      required: false
+      description: Passed through to the configured control-plane OAuth cleanup endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OAuthKeyCleanUpRequest"
+          example:
+            keyType: PRODUCTION
+            keyManager: Resident Key Manager
+    SDKGenerateBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SDKGenerateRequest"
+    BillingEngineKeysBody:
+      required: true
+      description: Billing engine credentials to encrypt and store for the organization.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BillingEngineKeysRequest"
+          example:
+            billingEngine: STRIPE
+            secretKey: sk_test_123
+            publishableKey: pk_test_123
+            webhookSecret: whsec_123
+    BillingEngineDeleteBody:
+      required: false
+      description: Optional billing engine selector. The same value can also be supplied with the `billingEngine` query parameter.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BillingEngineDeleteRequest"
+          example:
+            billingEngine: STRIPE
+    CheckoutSessionBody:
+      required: true
+      description: Paid subscription checkout payload.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CheckoutSessionRequest"
+          example:
+            applicationID: app-12345
+            apiId: api-7f4c2a6b
+            apiReferenceID: cp-api-12345
+            policyId: policy-pro
+            policyName: Pro
+            sourcePage: /devportal/apis/weather-api-v1
+    APIFlowCreateBody:
+      required: true
+      description: API flow creation payload. Use `contentType` `ARAZZO` for JSON/YAML workflow content or `MD` for Markdown flow content.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIFlowCreateRequest"
+          examples:
+            arazzoFlow:
+              summary: Create an Arazzo API flow
+              value:
+                name: Weather onboarding
+                handle: weather-onboarding
+                description: Guides users through the Weather API onboarding workflow.
+                contentType: ARAZZO
+                apiFlowDefinition:
+                  arazzo: 1.0.1
+                  info:
+                    title: Weather onboarding
+                    version: 1.0.0
+                  workflows: []
+            markdownFlow:
+              summary: Create a Markdown API flow
+              value:
+                name: Weather guide
+                description: Human-readable guide for Weather API users.
+                contentType: MD
+                markdownContent: "# Weather guide\nUse this flow to onboard Weather API users."
+    APIFlowUpdateBody:
+      required: true
+      description: API flow update payload. Include only the fields that should change.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIFlowUpdateRequest"
+          example:
+            name: Weather onboarding v2
+            status: PUBLISHED
+            visibility: PUBLIC
+            agentVisibility: VISIBLE
+    APIFlowPromptBody:
+      required: true
+      description: API flow prompt-generation payload.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIFlowPromptRequest"
+          example:
+            name: Weather onboarding
+            description: Guides users through the Weather API onboarding workflow.
+            orgHandle: acme
+            viewName: default
+            handle: weather-onboarding
+            apis:
+              - name: Weather API
+                version: v1
+    LoginBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/LoginRequest"
+    FileUploadBody:
+      required: true
+      description: ZIP file upload. Organization content uploads are limited to 50 MB.
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            required:
+              - file
+            properties:
+              file:
+                type: string
+                format: binary
+                description: ZIP file containing organization layout assets.
+    ApiMetadataMultipartBody:
+      required: true
+      description: >-
+        API metadata upload. Send either `artifact`, or `api` with `apiDefinition`, or `apiMetadata`
+        with `apiDefinition`. `schemaDefinition` is used for MCP APIs and GraphQL schema updates.
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              api:
+                type: string
+                format: binary
+                description: API metadata YAML file.
+              apiDefinition:
+                type: string
+                format: binary
+                description: API definition file.
+              artifact:
+                type: string
+                format: binary
+                description: Full API ZIP artifact containing metadata and definition files.
+              schemaDefinition:
+                type: string
+                format: binary
+                description: Schema definition file, used by MCP APIs.
+              apiMetadata:
+                type: string
+                description: JSON string accepted by the service when the `api` YAML file is not supplied.
+                example: >-
+                  {"apiInfo":{"apiName":"Weather API","apiVersion":"v1","apiDescription":"Weather forecast
+                  API","apiType":"REST","visibility":"PUBLIC","provider":"WSO2","apiStatus":"PUBLISHED","tags":["weather"],
+                  "labels":["default"]},"endPoints":{"productionURL":"https://api.example.com/weather",
+                  "sandboxURL":"https://sandbox.example.com/weather"},"subscriptionPolicies":[{"policyName":"Gold"}]}
+    ApiContentZipMultipartBody:
+      required: true
+      description: |
+        API content ZIP upload.
+
+        Expected ZIP structure:
+        - `web/`: optional API landing-page files and images.
+        - `docs/`: optional downloadable documents.
+
+        At least one of `web/` or `docs/` must exist at the ZIP root.
+        `docMetadata` and `imageMetadata` are JSON strings because they are submitted as multipart form fields.
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            required:
+              - apiContent
+            properties:
+              apiContent:
+                type: string
+                format: binary
+                description: ZIP upload field named `apiContent`.
+              docMetadata:
+                type: string
+                description: Optional JSON string containing API document link metadata.
+                example: '[{"name":"External guide","url":"https://example.com/docs/guide","type":"LINK"}]'
+              imageMetadata:
+                type: string
+                description: Optional JSON string containing API image metadata.
+                example: '{"api-icon":"icon.png"}'
+    ApplicationMultipartBody:
+      required: true
+      description: >-
+        Application payload. Send JSON, multipart form fields, or an application YAML file in the
+        `application` field. When YAML is used, the service reads `spec.displayName` or `metadata.name`
+        as the application name and `spec.description` as the description.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApplicationRequest"
+          example:
+            name: Weather App
+            description: Application used to call Weather APIs.
+            type: WEB
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              application:
+                type: string
+                format: binary
+                description: Application YAML file field named `application`.
+              name:
+                type: string
+                description: Application name when sending form fields instead of YAML.
+              description:
+                type: string
+              type:
+                type: string
+                default: WEB
+          examples:
+            formFields:
+              summary: Multipart form fields
+              value:
+                name: Weather App
+                description: Application used to call Weather APIs.
+                type: WEB
+            yamlFile:
+              summary: Application YAML upload
+              value:
+                application: application.yaml
+    ImportApplicationMultipartBody:
+      required: true
+      description: >-
+        Application import payload. The uploaded YAML describes the application, subscriptions, and
+        optionally application keys. Set `withKeys` to true only when importing keys for a specific
+        `keyManager`.
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            required:
+              - file
+            properties:
+              file:
+                type: string
+                format: binary
+                description: Imported application YAML file.
+              withKeys:
+                type: boolean
+                description: Whether to import application keys from the YAML.
+              keyManager:
+                type: string
+                description: Required when `withKeys` is true.
+          examples:
+            importWithoutKeys:
+              summary: Import application only
+              value:
+                file: application.yaml
+                withKeys: false
+            importWithKeys:
+              summary: Import application and keys
+              value:
+                file: application.yaml
+                withKeys: true
+                keyManager: Resident Key Manager
+  responses:
+    DefaultResponse:
+      description: Operation response. The exact schema is produced by the route handler.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericValue"
+    BinaryOrJsonResponse:
+      description: Binary, text, redirect, or JSON response depending on the requested resource.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericValue"
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+        text/plain:
+          schema:
+            type: string
+        text/html:
+          schema:
+            type: string
+    OrganizationResponse:
+      description: Organization DTO returned by create, update, and lookup operations.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OrganizationResponse"
+    OrganizationListResponse:
+      description: List of organization DTOs.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/OrganizationListItemResponse"
+    IdentityProviderResponse:
+      description: Identity provider DTO returned by create, update, and lookup operations.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/IdentityProviderResponse"
+    OrganizationContentUploadResponse:
+      description: Organization content upload accepted and stored successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OrganizationContentUploadResponse"
+    OrganizationContentAssetResponse:
+      description: Stored organization content asset.
+      content:
+        text/css:
+          schema:
+            type: string
+        text/html:
+          schema:
+            type: string
+        text/plain:
+          schema:
+            type: string
+        application/javascript:
+          schema:
+            type: string
+        image/svg+xml:
+          schema:
+            type: string
+        image/png:
+          schema:
+            type: string
+            format: binary
+        image/jpeg:
+          schema:
+            type: string
+            format: binary
+        image/gif:
+          schema:
+            type: string
+            format: binary
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+    APIContentAssetResponse:
+      description: >-
+        Stored API content asset. The concrete media type depends on the stored file extension or whether
+        the content is an external document link.
+      content:
+        text/css:
+          schema:
+            type: string
+          example: "body { color: #222; }"
+        text/html:
+          schema:
+            type: string
+          example: "<section>API overview</section>"
+        text/plain:
+          schema:
+            type: string
+          example: "https://example.com/docs/guide"
+        application/javascript:
+          schema:
+            type: string
+          example: "console.log('API content loaded');"
+        application/json:
+          schema:
+            type: string
+          example: '{"title":"API overview"}'
+        image/svg+xml:
+          schema:
+            type: string
+          example: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\"></svg>"
+        image/png:
+          schema:
+            type: string
+            format: binary
+        image/jpeg:
+          schema:
+            type: string
+            format: binary
+        image/gif:
+          schema:
+            type: string
+            format: binary
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+    OrganizationContentListResponse:
+      description: List of organization content records for the requested file type.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/OrganizationContentListItemResponse"
+    ProviderResponse:
+      description: Provider DTO returned by create and update operations.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProviderResponse"
+    ProviderLookupResponse:
+      description: Provider DTO or list of provider DTOs.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/ProviderLookupItemResponse"
+              - type: array
+                items:
+                  $ref: "#/components/schemas/ProviderLookupItemResponse"
+    BadRequest:
+      description: >-
+        Bad request. Input validation failures are returned as an array; other bad request errors
+        are returned as a standard error object.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/ValidationErrorList"
+              - $ref: "#/components/schemas/ErrorResponse"
+              - $ref: "#/components/schemas/MessageResponse"
+          examples:
+            validationError:
+              summary: Validation failure
+              value:
+                - code: "400"
+                  message: input validation failed
+                  description: Invalid value
+            badRequest:
+              summary: Bad request error
+              value:
+                code: "400"
+                message: Bad Request
+                description: "Missing required parameter: 'orgId'"
+            messageOnly:
+              summary: Message-only bad request
+              value:
+                message: Missing or invalid fields in the request payload
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            code: "404"
+            message: Resource Not Found
+            description: Organization not found
+    Conflict:
+      description: Duplicate organization data conflicts with an existing record.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            code: "409"
+            message: Conflict
+            description: Organization already exists
+    UnsupportedMediaType:
+      description: Unsupported request media type.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            code: "415"
+            message: Unsupported Media Type
+            description: Content-Type must be application/json
+    InternalServerError:
+      description: Internal server error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            code: "500"
+            message: Internal Server Error
+            description: Internal Server Error
+    MessageResponse:
+      description: JSON message response.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MessageResponse"
+    TextMessageResponse:
+      description: Plain text success response.
+      content:
+        text/plain:
+          schema:
+            type: string
+    EmptyResponse:
+      description: Operation completed successfully with no response body.
+    Forbidden:
+      description: Request is forbidden for the current runtime mode or caller permissions.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            code: "403"
+            message: Forbidden
+            description: Write operations are disabled in read-only mode
+    ApiMetadataCreateResponse:
+      description: Created API metadata payload returned by the service.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiMetadataCreateResponse"
+          example:
+            apiID: api-7f4c2a6b
+            apiReferenceID: cp-api-12345
+            apiHandle: weather-api-v1
+            provider: WSO2
+            dataSource: DEVPORTAL
+            apiInfo:
+              apiName: Weather API
+              apiTitle: Weather Forecast API
+              apiVersion: v1
+              apiDescription: Weather forecast API.
+              apiType: REST
+              visibility: PUBLIC
+              agentVisibility: VISIBLE
+              gatewayVendor: wso2
+              tokenBasedSubscriptionEnabled: false
+              gatewayType: null
+              tags:
+                - weather
+              labels:
+                - default
+            endPoints:
+              productionURL: https://api.example.com/weather
+              sandboxURL: https://sandbox.example.com/weather
+            monetizationInfo:
+              enabled: false
+            subscriptionPolicies:
+              - policyID: policy-gold
+                policyName: Gold
+                displayName: Gold
+                billingPlan: FREE
+                requestCount: 10000
+    ApiMetadataResponse:
+      description: API metadata DTO returned by the service.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiMetadataResponse"
+          example:
+            apiID: api-7f4c2a6b
+            apiReferenceID: cp-api-12345
+            apiHandle: weather-api-v1
+            provider: WSO2
+            dataSource: DEVPORTAL
+            apiInfo:
+              apiName: Weather API
+              apiTitle: Weather Forecast API
+              remotes: []
+              apiVersion: v1
+              apiDescription: Weather forecast API.
+              apiType: REST
+              visibility: PUBLIC
+              agentVisibility: VISIBLE
+              gatewayVendor: wso2
+              tokenBasedSubscriptionEnabled: false
+              gatewayType: null
+              labels:
+                - default
+            endPoints:
+              sandboxURL: https://sandbox.example.com/weather
+              productionURL: https://api.example.com/weather
+            monetizationInfo:
+              enabled: false
+            subscriptionPolicies:
+              - policyID: policy-gold
+                policyName: Gold
+                displayName: Gold
+                billingPlan: FREE
+                requestCount: 10000
+    ApiMetadataListResponse:
+      description: List of API metadata DTOs.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/ApiMetadataResponse"
+          example:
+            - apiID: api-7f4c2a6b
+              apiReferenceID: cp-api-12345
+              apiHandle: weather-api-v1
+              provider: WSO2
+              dataSource: DEVPORTAL
+              apiInfo:
+                apiName: Weather API
+                apiVersion: v1
+                apiDescription: Weather forecast API.
+                apiType: REST
+                visibility: PUBLIC
+                agentVisibility: VISIBLE
+                gatewayVendor: wso2
+                tokenBasedSubscriptionEnabled: false
+                gatewayType: null
+                labels:
+                  - default
+              endPoints:
+                sandboxURL: https://sandbox.example.com/weather
+                productionURL: https://api.example.com/weather
+              monetizationInfo:
+                enabled: false
+    SubscriptionPolicyResponse:
+      description: Subscription policy DTO.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SubscriptionPolicyResponse"
+    SubscriptionPolicyMutationResponse:
+      description: Subscription policy create/update response for single or bulk operations.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/SubscriptionPolicyResponse"
+              - type: array
+                items:
+                  $ref: "#/components/schemas/SubscriptionPolicyResponse"
+    SubscriptionPolicyPutResponse:
+      description: Subscription policy update response. Bulk updates may return a list, and some configurations return a message.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/SubscriptionPolicyResponse"
+              - type: array
+                items:
+                  $ref: "#/components/schemas/SubscriptionPolicyResponse"
+              - $ref: "#/components/schemas/MessageResponse"
+    LabelsResponse:
+      description: List of label DTOs.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/LabelResponse"
+          example:
+            - name: default
+              displayName: default
+            - name: premium
+              displayName: Premium APIs
+    ApplicationResponse:
+      description: Application DTO.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApplicationResponse"
+          example:
+            id: app-12345
+            name: Weather App
+            description: Application used to call Weather APIs.
+            type: WEB
+    ApplicationListResponse:
+      description: List of application DTOs.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/ApplicationResponse"
+          example:
+            - id: app-12345
+              name: Weather App
+              description: Application used to call Weather APIs.
+              type: WEB
+              appMap:
+                - appRefID: cp-app-98765
+                  token: OAUTH
+                  shared: true
+    ApplicationImportResponse:
+      description: Application import result.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApplicationImportResponse"
+          examples:
+            success:
+              summary: Import completed
+              value:
+                status: Success
+            incomplete:
+              summary: Import completed with subscription failures
+              value:
+                status: Incomplete
+                failedSubscriptions:
+                  - apiName: Weather API
+                    reason: Subscription policy not found
+    PlatformGatewaySubscriptionResponse:
+      description: Platform gateway subscription DTO returned by the control plane.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PlatformGatewaySubscriptionResponse"
+          example:
+            subscriptionId: sub-12345
+            apiId: cp-api-12345
+            apiName: Weather API
+            applicationId: cp-app-98765
+            subscriptionPlanName: Gold
+            status: ACTIVE
+            createdTime: "2026-05-07T08:30:00Z"
+    PlatformGatewaySubscriptionListResponse:
+      description: List of platform gateway subscription DTOs returned by the control plane.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  $ref: "#/components/schemas/PlatformGatewaySubscriptionResponse"
+              - type: object
+                properties:
+                  count:
+                    type: integer
+                  list:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PlatformGatewaySubscriptionResponse"
+                additionalProperties: true
+          example:
+            count: 1
+            list:
+              - subscriptionId: sub-12345
+                apiId: cp-api-12345
+                apiName: Weather API
+                applicationId: cp-app-98765
+                subscriptionPlanName: Gold
+                status: ACTIVE
+    PlatformApiKeyGenerateResponse:
+      description: Generated or regenerated platform API key response returned by the control plane.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PlatformApiKeyResponse"
+          example:
+            id: key-12345
+            name: weather_prod_key
+            apiId: cp-api-12345
+            token: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.example
+            expiresAt: "2026-12-31T23:59:59Z"
+            status: ACTIVE
+    PlatformApiKeyListResponse:
+      description: List of platform API key metadata records returned by the control plane.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  $ref: "#/components/schemas/PlatformApiKeyMetadataResponse"
+              - type: object
+                properties:
+                  count:
+                    type: integer
+                  list:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PlatformApiKeyMetadataResponse"
+                additionalProperties: true
+          example:
+            count: 1
+            list:
+              - id: key-12345
+                name: weather_prod_key
+                apiId: cp-api-12345
+                expiresAt: "2026-12-31T23:59:59Z"
+                status: ACTIVE
+                createdTime: "2026-05-07T08:30:00Z"
+    SubscriptionMessageResponse:
+      description: Subscription mutation result.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MessageResponse"
+          examples:
+            subscribed:
+              summary: Subscription created
+              value:
+                message: Subscribed successfully
+            updated:
+              summary: Subscription updated
+              value:
+                message: Updated subscription successfully
+    SubscriptionResponse:
+      description: Developer Portal subscription DTO.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SubscriptionResponse"
+          example:
+            id: sub-12345
+            appId: app-12345
+            apiId: cp-api-12345
+            policyId: policy-gold
+    SubscriptionListResponse:
+      description: List of Developer Portal subscription DTOs.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/SubscriptionResponse"
+          example:
+            - id: sub-12345
+              appId: app-12345
+              apiId: cp-api-12345
+              policyId: policy-gold
+    AppKeyMappingCreateResponse:
+      description: >-
+        Control-plane key generation or key mapping response, enriched with the control-plane application
+        reference and subscription scope keys.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AppKeyMappingCreateResponse"
+          example:
+            keyMappingId: km-12345
+            keyManager: Resident Key Manager
+            keyType: PRODUCTION
+            consumerKey: consumer-key-123
+            consumerSecret: consumer-secret-abc
+            supportedGrantTypes:
+              - client_credentials
+              - refresh_token
+            appRefId: cp-app-98765
+            subscriptionScopes:
+              - weather.read
+              - weather.write
+    AppKeyMappingListResponse:
+      description: Application row with stored control-plane key mapping entries.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AppKeyMappingListResponse"
+          example:
+            APP_ID: app-12345
+            ORG_ID: org-12345
+            CREATED_BY: user-12345
+            NAME: Weather App
+            DESCRIPTION: Application used to call Weather APIs.
+            TYPE: WEB
+            DP_APP_KEY_MAPPINGs:
+              - MAPPING_ID: map-12345
+                APP_ID: app-12345
+                CP_APP_REF: cp-app-98765
+                API_REF_ID: cp-api-12345
+                ORG_ID: org-12345
+                SUBSCRIPTION_REF_ID: cp-sub-12345
+                SHARED_TOKEN: true
+                TOKEN_TYPE: OAUTH
+    ApplicationApiKeyGenerateResponse:
+      description: API key generation or regeneration response returned by the control plane.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApplicationApiKeyResponse"
+          example:
+            id: api-key-12345
+            name: weather-prod-key
+            keyType: PRODUCTION
+            apiId: cp-api-12345
+            applicationId: cp-app-98765
+            apiKey: generated-api-key-value
+            appRefId: cp-app-98765
+    ApplicationKeyResponse:
+      description: Application OAuth key response returned by the control plane.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApplicationOAuthKeyResponse"
+          example:
+            keyMappingId: km-12345
+            keyManager: Resident Key Manager
+            keyType: PRODUCTION
+            consumerKey: consumer-key-123
+            consumerSecret: consumer-secret-abc
+            supportedGrantTypes:
+              - client_credentials
+              - refresh_token
+            callbackUrl: https://app.example.com/callback
+    OAuthTokenResponse:
+      description: OAuth access token response returned by the control plane.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OAuthTokenResponse"
+          example:
+            access_token: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.example
+            token_type: Bearer
+            expires_in: 3600
+            scope: weather.read
+    MessageOrGenericResponse:
+      description: Message or control-plane response payload.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/MessageResponse"
+              - $ref: "#/components/schemas/GenericObject"
+          example:
+            message: Operation completed successfully
+    BillingUsageDataResponse:
+      description: Billing usage summary for the authenticated user.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BillingUsageDataResponse"
+          example:
+            totalRequests: 12450
+            activeSubscriptions: 2
+            estimatedCost: 29.99
+            currency: USD
+            avgResponseTime: 142
+            subscriptions:
+              - apiName: Weather API
+                applicationName: Weather App
+                planName: Pro
+                requests: 12000
+                pricingModel: METERED
+                cost: 24.99
+                currency: USD
+                avgResponseTime: 145
+    PaymentMethodsResponse:
+      description: Stripe payment methods for the authenticated billing user.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PaymentMethodsResponse"
+          example:
+            paymentMethods:
+              - id: pm_12345
+                brand: visa
+                last4: "4242"
+                expMonth: 12
+                expYear: 2030
+                isDefault: true
+    BillingEngineKeysResponse:
+      description: Masked billing engine credentials.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BillingEngineKeysResponse"
+          example:
+            billingEngine: STRIPE
+            secretKey: "****"
+            publishableKey: "****"
+            webhookSecret: "****"
+    BillingInfoResponse:
+      description: Billing profile information for the authenticated user.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BillingInfoResponse"
+          example:
+            organizationName: Acme Inc
+            email: dev@example.com
+            address:
+              line1: 100 Market Street
+              city: San Francisco
+              country: US
+            taxId: "123456789"
+    BillingSubscriptionsResponse:
+      description: Subscriptions formatted for billing page display.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BillingSubscriptionsResponse"
+          example:
+            subscriptions:
+              - id: sub-12345
+                apiName: Weather API
+                applicationName: Weather App
+                planName: Pro
+                billingCycle: Month
+                amount: 2999
+                currency: usd
+                nextBillingDate: 1775088000000
+                status: active
+    CheckoutSessionResponse:
+      description: Stripe checkout session details for a pending paid subscription.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CheckoutSessionResponse"
+          example:
+            subId: sub-12345
+            checkoutSessionId: cs_test_12345
+            clientSecret: cs_test_12345_secret_abc
+            publishableKey: pk_test_123
+            billingCustomerId: cus_12345
+            paymentProvider: STRIPE
+            paymentStatus: PENDING
+    CheckoutRegistrationResponse:
+      description: Registered checkout session and activated subscription details.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CheckoutRegistrationResponse"
+          example:
+            subId: sub-12345
+            billingCustomerId: cus_12345
+            billingSubscriptionId: sub_stripe_12345
+            paymentStatus: ACTIVE
+            paymentProvider: STRIPE
+    BillingCancelResponse:
+      description: Paid subscription cancellation result.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BillingCancelResponse"
+          example:
+            subId: sub-12345
+            paymentStatus: CANCELED
+    SubscriptionBillingStatusResponse:
+      description: Billing status for a Developer Portal subscription.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SubscriptionBillingStatusResponse"
+          example:
+            subId: sub-12345
+            paymentProvider: STRIPE
+            paymentStatus: ACTIVE
+            billingCustomerId: cus_12345
+            billingSubscriptionId: sub_stripe_12345
+    BillingPortalResponse:
+      description: Stripe billing portal session URL.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BillingPortalResponse"
+          example:
+            url: https://billing.stripe.com/p/session/test_123
+    SubscriptionUsageResponse:
+      description: Usage metrics for a subscription.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SubscriptionUsageResponse"
+          example:
+            subscriptionId: cp-sub-12345
+            from: "2026-04-07T00:00:00Z"
+            to: "2026-05-07T00:00:00Z"
+            total_requests: 12000
+            avg_response_time: 145
+            currency: USD
+    UsageErrorResponse:
+      description: Usage lookup error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ControllerErrorResponse"
+          example:
+            error: CustomError
+            message: Invalid usageFrom date
+    InvoiceListResponse:
+      description: Compact invoice list for the authenticated billing user.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/InvoiceListResponse"
+          example:
+            invoices:
+              - id: in_12345
+                number: INV-001
+                created: 1775088000
+                amount: 2999
+                currency: usd
+                status: paid
+                hostedInvoiceUrl: https://invoice.stripe.com/i/acct/test
+                invoicePdf: https://pay.stripe.com/invoice/acct/test/pdf
+    StripeInvoiceListResponse:
+      description: Stripe invoice list response filtered by subscription.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/StripeInvoiceListResponse"
+          example:
+            object: list
+            data:
+              - id: in_12345
+                object: invoice
+                status: paid
+                hosted_invoice_url: https://invoice.stripe.com/i/acct/test
+                invoice_pdf: https://pay.stripe.com/invoice/acct/test/pdf
+            has_more: false
+    InvoiceResponse:
+      description: Stripe invoice object.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/StripeInvoiceResponse"
+          example:
+            id: in_12345
+            object: invoice
+            status: paid
+            customer: cus_12345
+            hosted_invoice_url: https://invoice.stripe.com/i/acct/test
+            invoice_pdf: https://pay.stripe.com/invoice/acct/test/pdf
+    InvoicePdfLinkResponse:
+      description: Hosted invoice and PDF links.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/InvoicePdfLinkResponse"
+          example:
+            invoiceId: in_12345
+            hosted_invoice_url: https://invoice.stripe.com/i/acct/test
+            invoice_pdf: https://pay.stripe.com/invoice/acct/test/pdf
+    InvoicePdfNotAvailableResponse:
+      description: Invoice PDF is not available yet.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/InvoicePdfNotAvailableResponse"
+          example:
+            error: InvoicePdfNotAvailable
+            message: Invoice PDF is not available for this invoice. It may not be finalized or paid yet.
+            hosted_invoice_url: https://invoice.stripe.com/i/acct/test
+    InvoiceErrorResponse:
+      description: Invoice lookup error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ControllerErrorResponse"
+          example:
+            error: InternalServerError
+            message: An unexpected error occurred
+    APIFlowCreateResponse:
+      description: Created API flow summary.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIFlowCreateResponse"
+          example:
+            apiFlowId: flow-12345
+            name: Weather onboarding
+            status: PUBLISHED
+    APIFlowResponse:
+      description: API flow DTO.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIFlowResponse"
+          example:
+            apiFlowId: flow-12345
+            name: Weather onboarding
+            handle: weather-onboarding
+            description: Guides users through the Weather API onboarding workflow.
+            agentPrompt: Follow this workflow to onboard a Weather API user.
+            status: PUBLISHED
+            visibility: PUBLIC
+            agentVisibility: VISIBLE
+            contentType: ARAZZO
+            apiFlowDefinition: '{"arazzo":"1.0.1","info":{"title":"Weather onboarding","version":"1.0.0"},"workflows":[]}'
+            markdownContent: null
+            createdAt: May 7, 2026
+            updatedAt: "2026-05-07T08:30:00Z"
+    APIFlowListResponse:
+      description: List of API flow DTOs.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/APIFlowResponse"
+    APIFlowPromptResponse:
+      description: Generated API flow agent prompt.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIFlowPromptResponse"
+          example:
+            agentPrompt: "You are an API workflow assistant. Help the user complete Weather onboarding."
+    TempArazzoFileResponse:
+      description: Path of the temporary Arazzo file.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TempArazzoFileResponse"
+          example:
+            path: /tmp/arazzo-abc123/workflow.arazzo.yaml
+    ViewResponse:
+      description: View DTO response.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ViewResponse"
+          example:
+            name: partner-apis
+            displayName: Partner APIs
+            labels:
+              - partner
+              - public
+    ViewsResponse:
+      description: List of view DTOs.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/ViewResponse"
+          example:
+            - name: default
+              displayName: Default
+              labels:
+                - default
+            - name: partner-apis
+              displayName: Partner APIs
+              labels:
+                - partner
+                - public
+    ViewUpdateEchoResponse:
+      description: Echo of the accepted view update payload.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ViewUpdateRequest"
+          example:
+            displayName: Partner and Public APIs
+            addedLabels:
+              - premium
+            removedLabels:
+              - internal
+  schemas:
+    MessageResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+    GenericValue:
+      nullable: true
+      oneOf:
+        - type: object
+          additionalProperties: true
+        - type: array
+          items: {}
+        - type: string
+        - type: number
+        - type: boolean
+    GenericObject:
+      type: object
+      additionalProperties: true
+    ErrorResponse:
+      type: object
+      required:
+        - code
+        - message
+        - description
+      properties:
+        code:
+          oneOf:
+            - type: string
+            - type: integer
+          description: HTTP status code returned by the error handler.
+        message:
+          type: string
+        description:
+          type: string
+      additionalProperties: false
+    ValidationErrorList:
+      type: array
+      items:
+        $ref: "#/components/schemas/ValidationError"
+    ValidationError:
+      type: object
+      required:
+        - code
+        - message
+        - description
+      properties:
+        code:
+          type: string
+          example: "400"
+        message:
+          type: string
+          example: input validation failed
+        description:
+          type: string
+      additionalProperties: false
+    OrganizationResponse:
+      type: object
+      properties:
+        orgId:
+          type: string
+        orgName:
+          type: string
+        businessOwner:
+          type: string
+          nullable: true
+        businessOwnerContact:
+          type: string
+          nullable: true
+        businessOwnerEmail:
+          type: string
+          format: email
+          nullable: true
+        orgHandle:
+          type: string
+        roleClaimName:
+          type: string
+        groupsClaimName:
+          type: string
+        organizationClaimName:
+          type: string
+        organizationIdentifier:
+          type: string
+        adminRole:
+          type: string
+        subscriberRole:
+          type: string
+        superAdminRole:
+          type: string
+          nullable: true
+        groupClaimName:
+          type: string
+          nullable: true
+        orgConfiguration:
+          $ref: "#/components/schemas/GenericObject"
+      additionalProperties: false
+    OrganizationListItemResponse:
+      type: object
+      properties:
+        orgID:
+          type: string
+        orgName:
+          type: string
+        businessOwner:
+          type: string
+          nullable: true
+        businessOwnerContact:
+          type: string
+          nullable: true
+        businessOwnerEmail:
+          type: string
+          format: email
+          nullable: true
+        orgHandle:
+          type: string
+        roleClaimName:
+          type: string
+        groupsClaimName:
+          type: string
+        organizationClaimName:
+          type: string
+        organizationIdentifier:
+          type: string
+        adminRole:
+          type: string
+        subscriberRole:
+          type: string
+        superAdminRole:
+          type: string
+          nullable: true
+        orgConfiguration:
+          $ref: "#/components/schemas/GenericObject"
+      additionalProperties: false
+    IdentityProviderResponse:
+      type: object
+      properties:
+        name:
+          type: string
+        issuer:
+          type: string
+        authorizationURL:
+          type: string
+          format: uri
+        tokenURL:
+          type: string
+          format: uri
+        clientId:
+          type: string
+        callbackURL:
+          type: string
+          format: uri
+        scope:
+          type: string
+          nullable: true
+        logoutURL:
+          type: string
+          format: uri
+        logoutRedirectURI:
+          type: string
+          format: uri
+        userInfoURL:
+          type: string
+          format: uri
+        signUpURL:
+          type: string
+          format: uri
+        jwksURL:
+          type: string
+          format: uri
+        certificate:
+          type: string
+      additionalProperties: false
+    OrganizationContentUploadResponse:
+      type: object
+      required:
+        - orgId
+        - fileName
+      properties:
+        orgId:
+          type: string
+        fileName:
+          type: string
+          description: Original ZIP file name uploaded in the `file` multipart field.
+      additionalProperties: false
+    OrganizationContentListItemResponse:
+      type: object
+      properties:
+        orgId:
+          type: string
+        fileName:
+          type: string
+        fileContent:
+          type: string
+          nullable: true
+          description: UTF-8 content string returned for stored organization content records.
+      additionalProperties: false
+    ProviderResponse:
+      type: object
+      required:
+        - orgId
+        - name
+        - providerURL
+      properties:
+        orgId:
+          type: string
+        name:
+          type: string
+        providerURL:
+          type: string
+          format: uri
+      additionalProperties: false
+    ProviderLookupItemResponse:
+      type: object
+      required:
+        - name
+        - providerURL
+      properties:
+        name:
+          type: string
+        providerURL:
+          type: string
+          format: uri
+      additionalProperties: false
+    ApiMetadataCreateResponse:
+      type: object
+      properties:
+        apiID:
+          type: string
+        apiReferenceID:
+          type: string
+        apiHandle:
+          type: string
+        provider:
+          type: string
+        dataSource:
+          type: string
+        apiInfo:
+          $ref: "#/components/schemas/ApiInfoResponse"
+        endPoints:
+          $ref: "#/components/schemas/ApiEndpointsResponse"
+        monetizationInfo:
+          $ref: "#/components/schemas/ApiMonetizationInfoResponse"
+        subscriptionPolicies:
+          type: array
+          items:
+            $ref: "#/components/schemas/SubscriptionPolicyResponse"
+      additionalProperties: true
+    ApiMetadataResponse:
+      type: object
+      properties:
+        apiID:
+          type: string
+        apiReferenceID:
+          type: string
+        apiHandle:
+          type: string
+        provider:
+          type: string
+        dataSource:
+          type: string
+        policyID:
+          type: string
+        apiInfo:
+          $ref: "#/components/schemas/ApiInfoResponse"
+        endPoints:
+          $ref: "#/components/schemas/ApiEndpointsResponse"
+        monetizationInfo:
+          $ref: "#/components/schemas/ApiMonetizationInfoResponse"
+        subscriptionPolicies:
+          type: array
+          items:
+            $ref: "#/components/schemas/SubscriptionPolicyResponse"
+      additionalProperties: false
+    ApiInfoResponse:
+      type: object
+      properties:
+        apiName:
+          type: string
+        apiTitle:
+          type: string
+          nullable: true
+        remotes:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        apiVersion:
+          type: string
+        apiDescription:
+          type: string
+        apiType:
+          type: string
+        visibility:
+          type: string
+        agentVisibility:
+          type: string
+        gatewayVendor:
+          type: string
+        tokenBasedSubscriptionEnabled:
+          type: boolean
+        gatewayType:
+          type: string
+          nullable: true
+        addedLabels:
+          type: array
+          items:
+            type: string
+        removedLabels:
+          type: array
+          items:
+            type: string
+        visibleGroups:
+          type: array
+          items:
+            type: string
+        owners:
+          $ref: "#/components/schemas/ApiOwnersResponse"
+        apiImageMetadata:
+          $ref: "#/components/schemas/ApiImageMetadataResponse"
+        tags:
+          type: array
+          items:
+            type: string
+        labels:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+    ApiOwnersResponse:
+      type: object
+      properties:
+        technicalOwner:
+          type: string
+        businessOwner:
+          type: string
+        businessOwnerEmail:
+          type: string
+        technicalOwnerEmail:
+          type: string
+      additionalProperties: false
+    ApiEndpointsResponse:
+      type: object
+      properties:
+        sandboxURL:
+          type: string
+        productionURL:
+          type: string
+      additionalProperties: false
+    ApiImageMetadataResponse:
+      type: object
+      additionalProperties:
+        type: string
+    ApiMonetizationInfoResponse:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+      additionalProperties: true
+    SubscriptionPolicyResponse:
+      type: object
+      properties:
+        policyID:
+          type: string
+        policyName:
+          type: string
+        displayName:
+          type: string
+        billingPlan:
+          type: string
+        description:
+          type: string
+        requestCount:
+          oneOf:
+            - type: integer
+            - type: string
+        orgID:
+          type: string
+        pricingModel:
+          type: string
+        currency:
+          type: string
+        billingPeriod:
+          type: string
+        flatAmount:
+          type: number
+        unitAmount:
+          type: number
+        pricingMetadata:
+          type: object
+          additionalProperties: true
+      additionalProperties: false
+    LabelResponse:
+      type: object
+      properties:
+        name:
+          type: string
+          example: premium
+        displayName:
+          type: string
+          example: Premium APIs
+      additionalProperties: false
+    ApplicationResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: app-12345
+        name:
+          type: string
+          example: Weather App
+        description:
+          type: string
+          example: Application used to call Weather APIs.
+        type:
+          type: string
+          example: WEB
+        appMap:
+          type: array
+          items:
+            $ref: "#/components/schemas/ApplicationKeyMappingSummary"
+      additionalProperties: false
+    ApplicationKeyMappingSummary:
+      type: object
+      properties:
+        appRefID:
+          type: string
+          example: cp-app-98765
+        token:
+          type: string
+          example: OAUTH
+        shared:
+          type: boolean
+          example: true
+      additionalProperties: false
+    ApplicationImportResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - Success
+            - Incomplete
+        failedSubscriptions:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+      additionalProperties: false
+    ViewResponse:
+      type: object
+      required:
+        - name
+        - displayName
+        - labels
+      properties:
+        name:
+          type: string
+          example: partner-apis
+        displayName:
+          type: string
+          example: Partner APIs
+        labels:
+          type: array
+          items:
+            type: string
+          example:
+            - partner
+            - public
+      additionalProperties: false
+    OrganizationCreateRequest:
+      type: object
+      required:
+        - orgName
+        - orgHandle
+        - roleClaimName
+        - groupsClaimName
+        - organizationClaimName
+        - organizationIdentifier
+        - adminRole
+        - subscriberRole
+        - superAdminRole
+      properties:
+        orgName:
+          type: string
+        businessOwner:
+          type: string
+        businessOwnerContact:
+          type: string
+        businessOwnerEmail:
+          type: string
+          format: email
+        orgHandle:
+          type: string
+          description: Public organization handle used in portal URLs.
+        roleClaimName:
+          type: string
+        groupsClaimName:
+          type: string
+        organizationClaimName:
+          type: string
+        organizationIdentifier:
+          type: string
+        adminRole:
+          type: string
+        subscriberRole:
+          type: string
+        superAdminRole:
+          type: string
+      additionalProperties: false
+    OrganizationUpdateRequest:
+      type: object
+      required:
+        - orgName
+        - orgHandle
+        - roleClaimName
+        - groupsClaimName
+        - organizationClaimName
+        - organizationIdentifier
+        - adminRole
+        - subscriberRole
+        - superAdminRole
+      properties:
+        orgName:
+          type: string
+        businessOwner:
+          type: string
+        businessOwnerContact:
+          type: string
+        businessOwnerEmail:
+          type: string
+          format: email
+        orgHandle:
+          type: string
+        roleClaimName:
+          type: string
+        groupsClaimName:
+          type: string
+        organizationClaimName:
+          type: string
+        organizationIdentifier:
+          type: string
+        adminRole:
+          type: string
+        subscriberRole:
+          type: string
+        superAdminRole:
+          type: string
+        orgConfiguration:
+          $ref: "#/components/schemas/GenericObject"
+    IdentityProviderRequest:
+      type: object
+      required:
+        - issuer
+        - name
+        - authorizationURL
+        - tokenURL
+        - clientId
+        - callbackURL
+        - logoutURL
+        - logoutRedirectURI
+      properties:
+        issuer:
+          type: string
+        name:
+          type: string
+        authorizationURL:
+          type: string
+          format: uri
+        tokenURL:
+          type: string
+          format: uri
+        userInfoURL:
+          type: string
+          format: uri
+        clientId:
+          type: string
+        callbackURL:
+          type: string
+          format: uri
+        signUpURL:
+          type: string
+          format: uri
+        logoutURL:
+          type: string
+          format: uri
+        logoutRedirectURI:
+          type: string
+          format: uri
+        scope:
+          type: string
+        jwksURL:
+          type: string
+          format: uri
+        certificate:
+          type: string
+      additionalProperties: false
+    ProviderRequest:
+      type: object
+      required:
+        - name
+        - providerURL
+      properties:
+        name:
+          type: string
+        providerURL:
+          type: string
+          format: uri
+      additionalProperties: false
+    SubscriptionPolicyRequest:
+      type: object
+      required:
+        - policyName
+        - displayName
+        - type
+      properties:
+        policyId:
+          type: string
+          description: Optional external/APIM policy UUID.
+        policyID:
+          type: string
+          description: Alternative casing accepted by the DAO.
+        policyName:
+          type: string
+        displayName:
+          type: string
+        billingPlan:
+          type: string
+          example: FREE
+        description:
+          type: string
+        type:
+          type: string
+          enum:
+            - requestcount
+            - eventcount
+          description: Service accepts case-insensitive `requestcount` or `eventcount`.
+        requestCount:
+          oneOf:
+            - type: integer
+            - type: string
+          description: Required for request-count policies. Use -1 for unlimited.
+        eventCount:
+          oneOf:
+            - type: integer
+            - type: string
+          description: Required for event-count policies. Use -1 for unlimited.
+        pricingModel:
+          type: string
+          enum:
+            - FREE
+            - FLAT
+            - PER_UNIT
+            - VOLUME_TIERS
+            - GRADUATED_TIERS
+        currency:
+          type: string
+          example: USD
+        billingPeriod:
+          type: string
+          example: month
+        flatAmount:
+          type: number
+        unitAmount:
+          type: number
+        externalProductId:
+          type: string
+        externalPriceId:
+          type: string
+        tiers:
+          type: array
+          items:
+            $ref: "#/components/schemas/PricingTier"
+        pricingTiers:
+          type: array
+          items:
+            $ref: "#/components/schemas/PricingTier"
+        billingMeterData:
+          type: array
+          items:
+            type: object
+            properties:
+              apiId:
+                type: string
+              meterId:
+                type: string
+    PricingTier:
+      type: object
+      properties:
+        tierIndex:
+          type: integer
+        startUnit:
+          type: integer
+        endUnit:
+          type: integer
+          nullable: true
+        unitPrice:
+          type: number
+          nullable: true
+        flatPrice:
+          type: number
+          nullable: true
+    LabelRequest:
+      type: object
+      required:
+        - name
+        - displayName
+      properties:
+        name:
+          type: string
+          example: premium
+        displayName:
+          type: string
+          example: Premium APIs
+      additionalProperties: false
+    ApplicationRequest:
+      type: object
+      required:
+        - name
+        - description
+      properties:
+        name:
+          type: string
+          example: Weather App
+        description:
+          type: string
+          example: Application used to call Weather APIs.
+        type:
+          type: string
+          default: WEB
+          example: WEB
+    PlatformGatewaySubscriptionCreateRequest:
+      type: object
+      required:
+        - apiId
+      properties:
+        apiId:
+          type: string
+          description: Developer Portal API ID.
+          example: api-7f4c2a6b
+        subscriptionPlanName:
+          type: string
+          description: Optional subscription plan name to use in the control plane.
+          example: Gold
+        applicationId:
+          type: string
+          description: Optional control-plane application ID.
+          example: cp-app-98765
+      additionalProperties: false
+    PlatformGatewaySubscriptionUpdateRequest:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - ACTIVE
+            - INACTIVE
+          example: ACTIVE
+      additionalProperties: false
+    PlatformGatewaySubscriptionResponse:
+      type: object
+      description: Platform gateway subscription payload returned by the control plane.
+      properties:
+        subscriptionId:
+          type: string
+          example: sub-12345
+        id:
+          type: string
+          description: Alternative subscription identifier used by some control-plane responses.
+          example: sub-12345
+        apiId:
+          type: string
+          description: Control-plane API reference ID.
+          example: cp-api-12345
+        apiName:
+          type: string
+          example: Weather API
+        applicationId:
+          type: string
+          example: cp-app-98765
+        applicationName:
+          type: string
+          example: Weather App
+        subscriptionPlanName:
+          type: string
+          example: Gold
+        status:
+          type: string
+          enum:
+            - ACTIVE
+            - INACTIVE
+            - ON_HOLD
+            - REJECTED
+            - TIER_UPDATE_PENDING
+          example: ACTIVE
+        createdTime:
+          type: string
+          format: date-time
+        updatedTime:
+          type: string
+          format: date-time
+      additionalProperties: true
+    PlatformApiKeyRequest:
+      type: object
+      required:
+        - apiId
+        - name
+      properties:
+        apiId:
+          type: string
+          description: Developer Portal API ID.
+          example: api-7f4c2a6b
+        name:
+          type: string
+          pattern: ^[a-z0-9][a-z0-9_-]{0,127}$
+          example: weather_prod_key
+        expiresAt:
+          oneOf:
+            - type: string
+              format: date-time
+            - type: number
+          description: Optional ISO-8601 datetime with timezone, epoch seconds, or epoch milliseconds.
+          example: "2026-12-31T23:59:59Z"
+      additionalProperties: false
+    PlatformApiKeyMetadataResponse:
+      type: object
+      description: Platform API key metadata returned by list operations. Secret material is normally omitted.
+      properties:
+        id:
+          type: string
+          example: key-12345
+        apiKeyId:
+          type: string
+          description: Alternative key identifier used by some control-plane responses.
+          example: key-12345
+        name:
+          type: string
+          example: weather_prod_key
+        apiId:
+          type: string
+          description: Control-plane API reference ID.
+          example: cp-api-12345
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+          example: "2026-12-31T23:59:59Z"
+        status:
+          type: string
+          example: ACTIVE
+        createdTime:
+          type: string
+          format: date-time
+        updatedTime:
+          type: string
+          format: date-time
+      additionalProperties: true
+    PlatformApiKeyResponse:
+      allOf:
+        - $ref: "#/components/schemas/PlatformApiKeyMetadataResponse"
+        - type: object
+          description: Platform API key response. The generated secret is returned only by generate/regenerate operations.
+          properties:
+            token:
+              type: string
+              description: Generated API key secret. Store this value securely because it may not be returned again.
+              example: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.example
+            apiKey:
+              type: string
+              description: Alternative generated secret field used by some control-plane responses.
+              example: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.example
+    SubscriptionRequest:
+      type: object
+      required:
+        - applicationID
+        - apiId
+        - policyId
+      properties:
+        applicationID:
+          type: string
+          description: Developer Portal application ID.
+          example: app-12345
+        apiId:
+          type: string
+          description: Developer Portal API ID.
+          example: api-7f4c2a6b
+        apiReferenceID:
+          type: string
+          description: Control-plane API reference ID, used when a CP subscription is created or updated.
+          example: cp-api-12345
+        policyId:
+          type: string
+          description: Developer Portal subscription policy ID.
+          example: policy-gold
+        policyName:
+          type: string
+          description: Subscription policy name used as throttling policy in the control plane.
+          example: Gold
+      additionalProperties: false
+    SubscriptionResponse:
+      type: object
+      required:
+        - id
+        - appId
+        - apiId
+        - policyId
+      properties:
+        id:
+          type: string
+          description: Developer Portal subscription ID.
+          example: sub-12345
+        appId:
+          type: string
+          description: Developer Portal application ID.
+          example: app-12345
+        apiId:
+          type: string
+          description: API reference ID stored on the subscription DTO.
+          example: cp-api-12345
+        policyId:
+          type: string
+          description: Developer Portal subscription policy ID.
+          example: policy-gold
+      additionalProperties: false
+    AppKeyMappingRequest:
+      type: object
+      required:
+        - applicationName
+        - tokenDetails
+      properties:
+        applicationName:
+          type: string
+          example: Weather App
+        apis:
+          type: array
+          description: Optional list of API identifiers. Existing service logic synchronizes subscribed APIs for the application.
+          items:
+            type: string
+          example:
+            - api-7f4c2a6b
+        tokenType:
+          type: string
+          enum:
+            - API_KEY
+            - OAUTH
+            - BASIC
+          example: OAUTH
+        provider:
+          type: string
+          example: WSO2
+        clientID:
+          type: string
+          description: Existing consumer key used when mapping external keys.
+          example: external-client-123
+        tokenDetails:
+          type: object
+          required:
+            - keyManager
+          properties:
+            keyManager:
+              type: string
+              example: Resident Key Manager
+            keyType:
+              type: string
+              enum:
+                - PRODUCTION
+                - SANDBOX
+              example: PRODUCTION
+            grantTypesToBeSupported:
+              type: array
+              items:
+                type: string
+              example:
+                - client_credentials
+                - refresh_token
+            callbackUrl:
+              type: string
+              format: uri
+              example: https://app.example.com/callback
+            additionalProperties:
+              type: object
+              additionalProperties: true
+              example:
+                application_access_token_expiry_time: "3600"
+                user_access_token_expiry_time: "3600"
+          additionalProperties: true
+      additionalProperties: false
+    AppKeyMappingCreateResponse:
+      type: object
+      description: >-
+        Control-plane OAuth key generation or mapped-key response. Exact fields can vary by key manager;
+        the Developer Portal always adds `appRefId` and normalized `subscriptionScopes`.
+      properties:
+        keyMappingId:
+          type: string
+          example: km-12345
+        keyManager:
+          type: string
+          example: Resident Key Manager
+        keyType:
+          type: string
+          example: PRODUCTION
+        consumerKey:
+          type: string
+          example: consumer-key-123
+        consumerSecret:
+          type: string
+          example: consumer-secret-abc
+        supportedGrantTypes:
+          type: array
+          items:
+            type: string
+          example:
+            - client_credentials
+            - refresh_token
+        appRefId:
+          type: string
+          description: Control-plane application reference ID.
+          example: cp-app-98765
+        subscriptionScopes:
+          type: array
+          description: Scope keys available through the application's subscriptions.
+          items:
+            type: string
+          example:
+            - weather.read
+            - weather.write
+      additionalProperties: true
+    AppKeyMappingListResponse:
+      type: object
+      description: Application row with included key mapping rows as returned by Sequelize.
+      properties:
+        APP_ID:
+          type: string
+          example: app-12345
+        ORG_ID:
+          type: string
+          example: org-12345
+        CREATED_BY:
+          type: string
+          example: user-12345
+        NAME:
+          type: string
+          example: Weather App
+        DESCRIPTION:
+          type: string
+          example: Application used to call Weather APIs.
+        TYPE:
+          type: string
+          example: WEB
+        DP_APP_KEY_MAPPINGs:
+          type: array
+          items:
+            $ref: "#/components/schemas/AppKeyMappingRowResponse"
+      additionalProperties: true
+    AppKeyMappingRowResponse:
+      type: object
+      properties:
+        MAPPING_ID:
+          type: string
+          example: map-12345
+        APP_ID:
+          type: string
+          example: app-12345
+        CP_APP_REF:
+          type: string
+          description: Control-plane application reference ID.
+          example: cp-app-98765
+        API_REF_ID:
+          type: string
+          nullable: true
+          description: Control-plane API reference ID. Null placeholder rows are used before API subscriptions are synchronized.
+          example: cp-api-12345
+        ORG_ID:
+          type: string
+          example: org-12345
+        SUBSCRIPTION_REF_ID:
+          type: string
+          nullable: true
+          description: Control-plane subscription reference ID.
+          example: cp-sub-12345
+        SHARED_TOKEN:
+          type: boolean
+          example: true
+        TOKEN_TYPE:
+          type: string
+          enum:
+            - API_KEY
+            - OAUTH
+            - BASIC
+          example: OAUTH
+      additionalProperties: true
+    ViewCreateRequest:
+      type: object
+      required:
+        - name
+        - labels
+      properties:
+        name:
+          type: string
+          example: partner-apis
+        displayName:
+          type: string
+          description: Optional display name. Defaults to `name` when omitted.
+          example: Partner APIs
+        labels:
+          type: array
+          minItems: 1
+          description: Label names to attach to the view.
+          items:
+            type: string
+          example:
+            - partner
+            - public
+      additionalProperties: false
+    ViewUpdateRequest:
+      type: object
+      properties:
+        displayName:
+          type: string
+          example: Partner and Public APIs
+        addedLabels:
+          type: array
+          description: Label names to attach to the view.
+          items:
+            type: string
+          example:
+            - premium
+        removedLabels:
+          type: array
+          description: Label names to detach from the view.
+          items:
+            type: string
+          example:
+            - internal
+      additionalProperties: false
+    ApiKeyGenerateRequest:
+      type: object
+      required:
+        - apiId
+        - devportalAppId
+        - projectID
+        - keyType
+      properties:
+        apiId:
+          type: string
+          description: Control-plane API reference ID.
+          example: cp-api-12345
+        applicationId:
+          type: string
+          description: Existing control-plane application ID, if one already exists.
+          example: cp-app-98765
+        devportalAppId:
+          type: string
+          description: Developer Portal application ID.
+          example: app-12345
+        projectID:
+          type: string
+          description: Project ID used to resolve environment templates.
+          example: project-12345
+        keyType:
+          type: string
+          enum:
+            - PRODUCTION
+            - SANDBOX
+          example: PRODUCTION
+        name:
+          type: string
+          description: Optional API key name. When omitted, the service generates a name from API handle, application reference, and key type.
+          example: weather-prod-key
+        subscriptionPlan:
+          oneOf:
+            - type: string
+            - $ref: "#/components/schemas/GenericObject"
+          description: Subscription plan or policy details forwarded when a control-plane subscription must be created.
+      additionalProperties: true
+    ApplicationKeysGenerateRequest:
+      type: object
+      description: OAuth key generation payload accepted by the control-plane application key endpoint.
+      properties:
+        keyType:
+          type: string
+          enum:
+            - PRODUCTION
+            - SANDBOX
+          example: PRODUCTION
+        keyManager:
+          type: string
+          example: Resident Key Manager
+        grantTypesToBeSupported:
+          type: array
+          items:
+            type: string
+          example:
+            - client_credentials
+            - refresh_token
+        callbackUrl:
+          type: string
+          format: uri
+          example: https://app.example.com/callback
+        additionalProperties:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+    OAuthGenerateTokenRequest:
+      type: object
+      description: OAuth access token generation payload accepted by the control plane.
+      properties:
+        scopes:
+          type: array
+          items:
+            type: string
+          example:
+            - weather.read
+        validityPeriod:
+          type: integer
+          example: 3600
+      additionalProperties: true
+    OAuthKeyUpdateRequest:
+      type: object
+      description: OAuth key update payload accepted by the control plane.
+      properties:
+        supportedGrantTypes:
+          type: array
+          items:
+            type: string
+          example:
+            - client_credentials
+            - refresh_token
+        callbackUrl:
+          type: string
+          format: uri
+          example: https://app.example.com/new-callback
+        additionalProperties:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+    OAuthKeyCleanUpRequest:
+      type: object
+      description: OAuth cleanup payload accepted by the control plane.
+      properties:
+        keyType:
+          type: string
+          enum:
+            - PRODUCTION
+            - SANDBOX
+          example: PRODUCTION
+        keyManager:
+          type: string
+          example: Resident Key Manager
+      additionalProperties: true
+    ApplicationApiKeyResponse:
+      type: object
+      description: API key payload returned by the control plane. The Developer Portal adds `appRefId` for generation responses.
+      properties:
+        id:
+          type: string
+          example: api-key-12345
+        apiKeyId:
+          type: string
+          example: api-key-12345
+        name:
+          type: string
+          example: weather-prod-key
+        keyType:
+          type: string
+          enum:
+            - PRODUCTION
+            - SANDBOX
+          example: PRODUCTION
+        apiId:
+          type: string
+          example: cp-api-12345
+        applicationId:
+          type: string
+          example: cp-app-98765
+        apiKey:
+          type: string
+          description: Generated API key secret.
+          example: generated-api-key-value
+        token:
+          type: string
+          description: Alternative generated key field used by some control-plane responses.
+          example: generated-api-key-value
+        appRefId:
+          type: string
+          description: Control-plane application reference ID added by Developer Portal generation flow.
+          example: cp-app-98765
+      additionalProperties: true
+    ApplicationOAuthKeyResponse:
+      type: object
+      description: OAuth key payload returned by the control plane.
+      properties:
+        keyMappingId:
+          type: string
+          example: km-12345
+        keyManager:
+          type: string
+          example: Resident Key Manager
+        keyType:
+          type: string
+          example: PRODUCTION
+        consumerKey:
+          type: string
+          example: consumer-key-123
+        consumerSecret:
+          type: string
+          example: consumer-secret-abc
+        supportedGrantTypes:
+          type: array
+          items:
+            type: string
+          example:
+            - client_credentials
+            - refresh_token
+        callbackUrl:
+          type: string
+          format: uri
+          example: https://app.example.com/callback
+      additionalProperties: true
+    OAuthTokenResponse:
+      type: object
+      properties:
+        access_token:
+          type: string
+          example: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.example
+        token_type:
+          type: string
+          example: Bearer
+        expires_in:
+          type: integer
+          example: 3600
+        scope:
+          type: string
+          example: weather.read
+      additionalProperties: true
+    SDKGenerateRequest:
+      type: object
+      required:
+        - selectedAPIs
+        - sdkConfiguration
+        - orgName
+      properties:
+        selectedAPIs:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            additionalProperties: true
+        sdkConfiguration:
+          type: object
+          additionalProperties: true
+        orgName:
+          type: string
+    BillingEngineKeysRequest:
+      type: object
+      required:
+        - billingEngine
+        - secretKey
+        - publishableKey
+        - webhookSecret
+      properties:
+        billingEngine:
+          type: string
+          example: STRIPE
+        secretKey:
+          type: string
+          description: Billing engine secret key. Stored encrypted and never returned in clear text.
+          example: sk_test_123
+        publishableKey:
+          type: string
+          example: pk_test_123
+        webhookSecret:
+          type: string
+          example: whsec_123
+      additionalProperties: false
+    BillingEngineDeleteRequest:
+      type: object
+      properties:
+        billingEngine:
+          type: string
+          example: STRIPE
+      additionalProperties: false
+    BillingEngineKeysResponse:
+      type: object
+      required:
+        - billingEngine
+      properties:
+        billingEngine:
+          type: string
+          example: STRIPE
+        secretKey:
+          type: string
+          nullable: true
+          description: Masked secret key marker when configured.
+          example: "****"
+        publishableKey:
+          type: string
+          nullable: true
+          description: Masked publishable key marker when configured.
+          example: "****"
+        webhookSecret:
+          type: string
+          nullable: true
+          description: Masked webhook secret marker when configured.
+          example: "****"
+      additionalProperties: false
+    CheckoutSessionRequest:
+      type: object
+      required:
+        - applicationID
+        - apiId
+        - apiReferenceID
+        - policyId
+        - policyName
+      properties:
+        applicationID:
+          type: string
+          description: Developer Portal application ID.
+          example: app-12345
+        apiId:
+          type: string
+          description: Developer Portal API ID.
+          example: api-7f4c2a6b
+        apiReferenceID:
+          type: string
+          description: Control-plane API reference ID.
+          example: cp-api-12345
+        policyId:
+          type: string
+          description: Developer Portal subscription policy ID.
+          example: policy-pro
+        policyName:
+          type: string
+          description: Subscription policy name.
+          example: Pro
+        sourcePage:
+          type: string
+          description: Portal page to return to after checkout.
+          example: /devportal/apis/weather-api-v1
+      additionalProperties: false
+    BillingUsageDataResponse:
+      type: object
+      properties:
+        totalRequests:
+          type: integer
+          example: 12450
+        activeSubscriptions:
+          type: integer
+          example: 2
+        estimatedCost:
+          type: number
+          example: 29.99
+        currency:
+          type: string
+          example: USD
+        avgResponseTime:
+          type: integer
+          description: Average response time in milliseconds.
+          example: 142
+        subscriptions:
+          type: array
+          items:
+            $ref: "#/components/schemas/BillingUsageSubscription"
+      additionalProperties: false
+    BillingUsageSubscription:
+      type: object
+      properties:
+        apiName:
+          type: string
+          example: Weather API
+        applicationName:
+          type: string
+          example: Weather App
+        planName:
+          type: string
+          example: Pro
+        requests:
+          type: integer
+          example: 12000
+        pricingModel:
+          type: string
+          example: METERED
+        cost:
+          type: number
+          example: 24.99
+        currency:
+          type: string
+          example: USD
+        avgResponseTime:
+          type: integer
+          example: 145
+      additionalProperties: true
+    PaymentMethodsResponse:
+      type: object
+      properties:
+        paymentMethods:
+          type: array
+          items:
+            $ref: "#/components/schemas/PaymentMethodResponse"
+      additionalProperties: false
+    PaymentMethodResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: pm_12345
+        brand:
+          type: string
+          example: visa
+        last4:
+          type: string
+          example: "4242"
+        expMonth:
+          type: integer
+          example: 12
+        expYear:
+          type: integer
+          example: 2030
+        isDefault:
+          type: boolean
+          example: true
+      additionalProperties: false
+    BillingInfoResponse:
+      type: object
+      properties:
+        organizationName:
+          type: string
+          example: Acme Inc
+        email:
+          type: string
+          format: email
+          example: dev@example.com
+        address:
+          type: object
+          nullable: true
+          additionalProperties: true
+        taxId:
+          type: string
+          nullable: true
+          example: "123456789"
+      additionalProperties: true
+    BillingSubscriptionsResponse:
+      type: object
+      properties:
+        subscriptions:
+          type: array
+          items:
+            $ref: "#/components/schemas/BillingSubscriptionResponse"
+      additionalProperties: false
+    BillingSubscriptionResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: sub-12345
+        apiName:
+          type: string
+          example: Weather API
+        applicationName:
+          type: string
+          example: Weather App
+        planName:
+          type: string
+          example: Pro
+        billingCycle:
+          type: string
+          example: Month
+        amount:
+          type: number
+          description: Amount in the smallest Stripe currency unit when sourced from Stripe.
+          example: 2999
+        currency:
+          type: string
+          example: usd
+        nextBillingDate:
+          type: integer
+          nullable: true
+          description: Next billing timestamp in milliseconds since epoch.
+          example: 1775088000000
+        status:
+          type: string
+          example: active
+      additionalProperties: true
+    CheckoutSessionResponse:
+      type: object
+      properties:
+        subId:
+          type: string
+          example: sub-12345
+        checkoutSessionId:
+          type: string
+          example: cs_test_12345
+        clientSecret:
+          type: string
+          example: cs_test_12345_secret_abc
+        publishableKey:
+          type: string
+          example: pk_test_123
+        billingCustomerId:
+          type: string
+          example: cus_12345
+        paymentProvider:
+          type: string
+          example: STRIPE
+        paymentStatus:
+          type: string
+          example: PENDING
+      additionalProperties: true
+    CheckoutRegistrationResponse:
+      type: object
+      properties:
+        subId:
+          type: string
+          example: sub-12345
+        billingCustomerId:
+          type: string
+          example: cus_12345
+        billingSubscriptionId:
+          type: string
+          example: sub_stripe_12345
+        paymentStatus:
+          type: string
+          example: ACTIVE
+        paymentProvider:
+          type: string
+          example: STRIPE
+      additionalProperties: true
+    BillingCancelResponse:
+      type: object
+      properties:
+        subId:
+          type: string
+          example: sub-12345
+        paymentStatus:
+          type: string
+          example: CANCELED
+      additionalProperties: false
+    SubscriptionBillingStatusResponse:
+      type: object
+      properties:
+        subId:
+          type: string
+          example: sub-12345
+        paymentProvider:
+          type: string
+          nullable: true
+          example: STRIPE
+        paymentStatus:
+          type: string
+          nullable: true
+          example: ACTIVE
+        billingCustomerId:
+          type: string
+          nullable: true
+          example: cus_12345
+        billingSubscriptionId:
+          type: string
+          nullable: true
+          example: sub_stripe_12345
+      additionalProperties: false
+    BillingPortalResponse:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          example: https://billing.stripe.com/p/session/test_123
+      additionalProperties: false
+    ControllerErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          example: InternalServerError
+        message:
+          type: string
+          example: An unexpected error occurred
+        description:
+          type: string
+      additionalProperties: true
+    SubscriptionUsageResponse:
+      type: object
+      description: Usage response returned by the monetization service or Moesif proxy.
+      properties:
+        subscriptionId:
+          type: string
+          example: cp-sub-12345
+        from:
+          type: string
+          format: date-time
+        to:
+          type: string
+          format: date-time
+        total_requests:
+          type: integer
+          example: 12000
+        usage:
+          type: integer
+          example: 12000
+        avg_response_time:
+          type: number
+          example: 145
+        currency:
+          type: string
+          example: USD
+      additionalProperties: true
+    InvoiceListResponse:
+      type: object
+      properties:
+        invoices:
+          type: array
+          items:
+            $ref: "#/components/schemas/InvoiceSummaryResponse"
+      additionalProperties: false
+    InvoiceSummaryResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: in_12345
+        number:
+          type: string
+          nullable: true
+          example: INV-001
+        created:
+          type: integer
+          description: Stripe-created timestamp in seconds.
+          example: 1775088000
+        amount:
+          type: number
+          example: 2999
+        currency:
+          type: string
+          example: usd
+        status:
+          type: string
+          example: paid
+        hostedInvoiceUrl:
+          type: string
+          format: uri
+          nullable: true
+        invoicePdf:
+          type: string
+          format: uri
+          nullable: true
+      additionalProperties: false
+    StripeInvoiceListResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          example: list
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/StripeInvoiceResponse"
+        has_more:
+          type: boolean
+          example: false
+        url:
+          type: string
+      additionalProperties: true
+    StripeInvoiceResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: in_12345
+        object:
+          type: string
+          example: invoice
+        status:
+          type: string
+          example: paid
+        customer:
+          oneOf:
+            - type: string
+            - type: object
+              additionalProperties: true
+        subscription:
+          type: string
+          nullable: true
+          example: sub_stripe_12345
+        hosted_invoice_url:
+          type: string
+          format: uri
+          nullable: true
+        invoice_pdf:
+          type: string
+          format: uri
+          nullable: true
+      additionalProperties: true
+    InvoicePdfLinkResponse:
+      type: object
+      properties:
+        invoiceId:
+          type: string
+          example: in_12345
+        hosted_invoice_url:
+          type: string
+          format: uri
+          nullable: true
+        invoice_pdf:
+          type: string
+          format: uri
+      additionalProperties: false
+    InvoicePdfNotAvailableResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          example: InvoicePdfNotAvailable
+        message:
+          type: string
+        hosted_invoice_url:
+          type: string
+          format: uri
+          nullable: true
+      additionalProperties: false
+    APIFlowCreateResponse:
+      type: object
+      properties:
+        apiFlowId:
+          type: string
+          example: flow-12345
+        name:
+          type: string
+          example: Weather onboarding
+        status:
+          type: string
+          example: PUBLISHED
+      additionalProperties: false
+    APIFlowResponse:
+      type: object
+      properties:
+        apiFlowId:
+          type: string
+          example: flow-12345
+        name:
+          type: string
+          example: Weather onboarding
+        handle:
+          type: string
+          example: weather-onboarding
+        description:
+          type: string
+        agentPrompt:
+          type: string
+        status:
+          type: string
+          example: PUBLISHED
+        visibility:
+          type: string
+          example: PUBLIC
+        agentVisibility:
+          type: string
+          example: VISIBLE
+        contentType:
+          type: string
+          enum:
+            - ARAZZO
+            - MD
+        apiFlowDefinition:
+          type: string
+          nullable: true
+        markdownContent:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          example: May 7, 2026
+        updatedAt:
+          type: string
+          nullable: true
+      additionalProperties: false
+    APIFlowPromptResponse:
+      type: object
+      properties:
+        agentPrompt:
+          type: string
+      additionalProperties: false
+    TempArazzoFileResponse:
+      type: object
+      properties:
+        path:
+          type: string
+          example: /tmp/arazzo-abc123/workflow.arazzo.yaml
+      additionalProperties: false
+    APIFlowCreateRequest:
+      type: object
+      required:
+        - name
+        - description
+      properties:
+        name:
+          type: string
+          example: Weather onboarding
+        handle:
+          type: string
+          example: weather-onboarding
+        description:
+          type: string
+          example: Guides users through the Weather API onboarding workflow.
+        agentPrompt:
+          type: string
+          example: Follow this workflow to onboard a Weather API user.
+        status:
+          type: string
+          default: PUBLISHED
+          example: PUBLISHED
+        visibility:
+          type: string
+          default: PUBLIC
+          example: PUBLIC
+        agentVisibility:
+          type: string
+          default: VISIBLE
+          example: VISIBLE
+        contentType:
+          type: string
+          enum:
+            - ARAZZO
+            - MD
+          default: ARAZZO
+        apiFlowDefinition:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: string
+          description: JSON/YAML Arazzo content when `contentType` is `ARAZZO`.
+        markdownContent:
+          type: string
+          description: Markdown content when `contentType` is `MD`.
+    APIFlowUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          example: Weather onboarding v2
+        handle:
+          type: string
+          example: weather-onboarding-v2
+        description:
+          type: string
+          example: Updated Weather API onboarding workflow.
+        agentPrompt:
+          type: string
+        status:
+          type: string
+          example: PUBLISHED
+        visibility:
+          type: string
+          example: PUBLIC
+        agentVisibility:
+          type: string
+          example: VISIBLE
+        contentType:
+          type: string
+          enum:
+            - ARAZZO
+            - MD
+        apiFlowDefinition:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: string
+        markdownContent:
+          type: string
+    APIFlowPromptRequest:
+      type: object
+      required:
+        - name
+        - description
+      properties:
+        name:
+          type: string
+          example: Weather onboarding
+        description:
+          type: string
+          example: Guides users through the Weather API onboarding workflow.
+        apis:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        orgHandle:
+          type: string
+          example: acme
+        viewName:
+          type: string
+          default: default
+          example: default
+        handle:
+          type: string
+          example: weather-onboarding
+    LoginRequest:
+      type: object
+      required:
+        - username
+        - password
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+          format: password
+    TempArazzoFileRequest:
+      type: object
+      required:
+        - content
+      properties:
+        content:
+          type: string
+          description: Arazzo YAML content to write to a temporary file.
+          example: "arazzo: 1.0.1\ninfo:\n  title: Weather onboarding\n  version: 1.0.0\nworkflows: []\n"
+        filename:
+          type: string
+          example: workflow.arazzo.yaml
+          default: workflow.arazzo.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "dotenv": "17.4.2",
         "express": "4.21.2",
         "express-handlebars": "7.1.3",
+        "express-openapi-validator": "4.13.8",
         "express-session": "1.18.1",
         "express-validator": "7.2.0",
         "fs-extra": "11.2.0",
@@ -71,6 +72,18 @@
         "eslint": "9.15.0",
         "globals": "15.12.0",
         "pkg": "5.8.1"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -795,6 +808,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
     },
     "node_modules/@lezer/common": {
       "version": "1.2.1",
@@ -2119,12 +2138,31 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/codemirror": {
       "version": "5.60.15",
       "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.15.tgz",
       "integrity": "sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==",
       "dependencies": {
         "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -2140,6 +2178,29 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/formidable": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.2.8.tgz",
@@ -2149,16 +2210,30 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+    },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.5.0",
@@ -2166,6 +2241,37 @@
       "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/shimmer": {
@@ -2273,7 +2379,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2885,6 +2990,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -4426,6 +4537,41 @@
         "node": ">=v16"
       }
     },
+    "node_modules/express-openapi-validator": {
+      "version": "4.13.8",
+      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-4.13.8.tgz",
+      "integrity": "sha512-89/sdkq+BKBuIyykaMl/vR9grFc3WFUPTjFo0THHbu+5g+q8rA7fKeoMfz+h84yOQIBcztmJ5ZJdk5uhEls31A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/multer": "^1.4.7",
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.4",
+        "json-schema-ref-parser": "^9.0.9",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.get": "^4.4.2",
+        "lodash.uniq": "^4.5.0",
+        "lodash.zipobject": "^4.1.3",
+        "media-typer": "^1.1.0",
+        "multer": "^1.4.5-lts.1",
+        "ono": "^7.1.3",
+        "path-to-regexp": "^6.2.0"
+      }
+    },
+    "node_modules/express-openapi-validator/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-openapi-validator/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
     "node_modules/express-session": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
@@ -4486,8 +4632,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -4515,8 +4660,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -5852,11 +5996,23 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
+    "node_modules/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
+      "deprecated": "Please switch to @apidevtools/json-schema-ref-parser",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "9.0.9"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6018,10 +6174,23 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -6070,6 +6239,18 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.zipobject": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash.zipobject/-/lodash.zipobject-4.18.0.tgz",
+      "integrity": "sha512-crXabtkOHmlyg/VoiR0wzEjbl8b+owY2Z8wBhoyoGPya/9YkUsxpCe7UJkL+ZtQFBBQXnk08kz9W0iieQNeu9w==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -9170,6 +9351,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-9jnfVriq7uJM4o5ganUY54ntUm+5EK21EGaQ5NWnkWg3zz5ywbbonlBguRcnmF1/HDiIe3zxNxXcO1YPBmPcQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "7.1.3"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -9965,7 +10155,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11527,7 +11716,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "crypto": "1.0.1",
     "express": "4.21.2",
     "express-handlebars": "7.1.3",
+    "express-openapi-validator": "4.13.8",
     "express-session": "1.18.1",
     "express-validator": "7.2.0",
     "fs-extra": "11.2.0",

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -59,14 +59,14 @@ advanced:
   # Mount the OpenAPI-spec-driven /devportal router (request validation + fine-grained
   # OAuth2 scope enforcement, dispatching by operationId to src/openapi/handlers).
   # When false, the legacy src/routes/devportalRoute.js is mounted instead.
-  useOpenApiValidator: false
   openApiValidator:
+    enabled: true          # Set to false to disable the OpenAPI validator and use legacy routing
     # Response validation strategy. Off by default in production.
     #   false      — disabled
     #   true       — strict; responses that don't match the spec become 500s
     #   'log-only' — log drift via warn-level logs but send the response anyway
     # When unset, enabled only if mode == "development".
-    validateResponses: false
+    validateResponses: false 
 
 # ─── TLS Certificates (only needed when advanced.http is false) ────────────────
 

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -60,6 +60,13 @@ advanced:
   # OAuth2 scope enforcement, dispatching by operationId to src/openapi/handlers).
   # When false, the legacy src/routes/devportalRoute.js is mounted instead.
   useOpenApiValidator: false
+  openApiValidator:
+    # Response validation strategy. Off by default in production.
+    #   false      — disabled
+    #   true       — strict; responses that don't match the spec become 500s
+    #   'log-only' — log drift via warn-level logs but send the response anyway
+    # When unset, enabled only if mode == "development".
+    validateResponses: false
 
 # ─── TLS Certificates (only needed when advanced.http is false) ────────────────
 

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -62,11 +62,11 @@ advanced:
   openApiValidator:
     enabled: true          # Set to false to disable the OpenAPI validator and use legacy routing
     # Response validation strategy. Off by default in production.
-    #   false      — disabled
-    #   true       — strict; responses that don't match the spec become 500s
+    #   off      — disabled
+    #   strict     — strict; responses that don't match the spec become 500s
     #   'log-only' — log drift via warn-level logs but send the response anyway
     # When unset, enabled only if mode == "development".
-    validateResponses: false 
+    validateResponses: off 
 
 # ─── TLS Certificates (only needed when advanced.http is false) ────────────────
 

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -92,6 +92,7 @@ identityProvider:
   logoutRedirectURI: "http://localhost:3000/ACME"
   certificate: ""
   jwksURL: "https://localhost:9443/oauth2/jwks"
+  tokenRefreshTimeoutMs: 10000
 
 # ─── Local / Default Auth ──────────────────────────────────────────────────────
 # Built-in local users for first-time exploration. Disable in production by

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -56,6 +56,10 @@ advanced:
     keyValue: "x-wso2-api-key"
   tokenExchanger:
     enabled: false
+  # Mount the OpenAPI-spec-driven /devportal router (request validation + fine-grained
+  # OAuth2 scope enforcement, dispatching by operationId to src/openapi/handlers).
+  # When false, the legacy src/routes/devportalRoute.js is mounted instead.
+  useOpenApiValidator: false
 
 # ─── TLS Certificates (only needed when advanced.http is false) ────────────────
 

--- a/scripts/drift_check.js
+++ b/scripts/drift_check.js
@@ -57,28 +57,28 @@ function deref(ref) {
     return cur;
 }
 
-function inlineRefs(node, seen = new Set()) {
-    if (Array.isArray(node)) return node.map(n => inlineRefs(n, seen));
-    if (!node || typeof node !== 'object') return node;
-    if (node.$ref) {
-        if (seen.has(node.$ref)) return {};
-        seen.add(node.$ref);
-        const out = inlineRefs(deref(node.$ref), seen);
-        seen.delete(node.$ref);
-        return out;
-    }
-    const out = {};
-    for (const [k, v] of Object.entries(node)) out[k] = inlineRefs(v, seen);
-    return out;
+function validationSchema(schema) {
+    // Keep $refs intact so AJV can validate recursive schemas instead of
+    // replacing cycle edges with permissive `{}` schemas.
+    return {
+        components: SPEC.components,
+        allOf: [schema],
+    };
 }
 
 // Match express-openapi-validator's AJV config (see node_modules/express-openapi-validator/dist/framework/ajv/options.js).
 // `nullable: true` makes OpenAPI 3.0 `nullable: true` declarations honored — without this, AJV rejects `null` for any typed field.
-const ajv = new Ajv({ allErrors: true, jsonPointers: true, nullable: true, useDefaults: true });
+const ajv = new Ajv({
+    allErrors: true,
+    jsonPointers: true,
+    nullable: true,
+    useDefaults: true,
+    logger: false,
+});
 
 function validate(schema, value) {
     try {
-        const v = ajv.compile(inlineRefs(schema));
+        const v = ajv.compile(validationSchema(schema));
         const ok = v(value);
         return { ok, errors: v.errors || [] };
     } catch (e) {

--- a/scripts/drift_check.js
+++ b/scripts/drift_check.js
@@ -1,0 +1,226 @@
+/*
+ * Spec ↔ service response drift checker.
+ *
+ * Validates representative response payloads (drawn directly from service code)
+ * against the spec response schemas using AJV — the same engine
+ * express-openapi-validator uses internally.
+ *
+ *   node scripts/drift_check.js
+ *
+ * Exit code 0 means every sample matches the spec. Exit code 1 means at least
+ * one sample failed validation; the failing operationId, status, and AJV
+ * error path are printed.
+ *
+ * --- Authoring samples ---
+ *
+ * Each sample MUST mirror what the legacy service actually emits today
+ * (look at the corresponding `res.status(...).send(...)` / `res.json(...)`
+ * call in the service file, NOT what the spec says it should emit). The
+ * point is to catch drift between the two; using a spec-shaped sample
+ * masks drift.
+ *
+ * As you find drift in production via `validateResponses: 'log-only'`, add a
+ * canned sample here so the regression is caught at boot.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const yaml = require('js-yaml');
+const Ajv = require('ajv');
+
+const SPEC = yaml.load(
+    fs.readFileSync(path.join(__dirname, '..', 'docs/devportal-openapi-spec-v1.yaml'), 'utf8')
+);
+
+function deref(ref) {
+    const parts = ref.replace(/^#\//, '').split('/');
+    let cur = SPEC;
+    for (const p of parts) cur = cur[p];
+    return cur;
+}
+
+function inlineRefs(node, seen = new Set()) {
+    if (Array.isArray(node)) return node.map(n => inlineRefs(n, seen));
+    if (!node || typeof node !== 'object') return node;
+    if (node.$ref) {
+        if (seen.has(node.$ref)) return {};
+        seen.add(node.$ref);
+        const out = inlineRefs(deref(node.$ref), seen);
+        seen.delete(node.$ref);
+        return out;
+    }
+    const out = {};
+    for (const [k, v] of Object.entries(node)) out[k] = inlineRefs(v, seen);
+    return out;
+}
+
+// Match express-openapi-validator's AJV config (see node_modules/express-openapi-validator/dist/framework/ajv/options.js).
+// `nullable: true` makes OpenAPI 3.0 `nullable: true` declarations honored — without this, AJV rejects `null` for any typed field.
+const ajv = new Ajv({ allErrors: true, jsonPointers: true, nullable: true, useDefaults: true });
+
+function validate(schema, value) {
+    try {
+        const v = ajv.compile(inlineRefs(schema));
+        const ok = v(value);
+        return { ok, errors: v.errors || [] };
+    } catch (e) {
+        return { ok: false, errors: [{ message: 'compile error: ' + e.message }] };
+    }
+}
+
+function responseSchema(operationId, status) {
+    for (const methods of Object.values(SPEC.paths)) {
+        for (const [m, op] of Object.entries(methods)) {
+            if (m === 'parameters') continue;
+            if (op.operationId !== operationId) continue;
+            const resp = (op.responses || {})[String(status)];
+            if (!resp) return null;
+            const r = resp.$ref ? deref(resp.$ref) : resp;
+            const json = r.content && r.content['application/json'];
+            if (!json) return { plainText: true };
+            return json.schema;
+        }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Samples — taken verbatim from the legacy service / controller code.
+// Add to this list as new drift cases surface from runtime log-only validation.
+// ---------------------------------------------------------------------------
+
+const SAMPLES = [
+    // Organizations — adminService.createOrganization L105-120 emits no superAdminRole;
+    // spec marks it nullable so this passes.
+    ['createOrganization', 201, {
+        orgId: 'org-1', orgName: 'Acme', businessOwner: 'Jane', businessOwnerContact: '+1',
+        businessOwnerEmail: 'jane@acme.example', orgHandle: 'acme',
+        roleClaimName: 'roles', groupsClaimName: 'groups',
+        organizationClaimName: 'organizationIdentifier', organizationIdentifier: 'ACME',
+        adminRole: 'admin', subscriberRole: 'sub', groupClaimName: 'group',
+        orgConfiguration: {},
+    }],
+    ['getOrganizations', 200, [{
+        orgName: 'Acme', orgID: 'org-1', businessOwner: 'Jane',
+        businessOwnerContact: '+1', businessOwnerEmail: 'jane@acme.example',
+        orgHandle: 'acme', roleClaimName: 'roles', groupsClaimName: 'groups',
+        organizationClaimName: 'organizationIdentifier', organizationIdentifier: 'ACME',
+        adminRole: 'admin', subscriberRole: 'sub', superAdminRole: 'super',
+        orgConfiguration: {},
+    }]],
+    ['getOrganization', 200, {
+        orgId: 'org-1', orgName: 'Acme', businessOwner: 'Jane', businessOwnerContact: '+1',
+        businessOwnerEmail: 'jane@acme.example', orgHandle: 'acme',
+        roleClaimName: 'roles', groupsClaimName: 'groups',
+        organizationClaimName: 'organizationIdentifier', organizationIdentifier: 'ACME',
+        adminRole: 'admin', superAdminRole: 'super', subscriberRole: 'sub',
+        groupClaimName: 'group', orgConfiguration: {},
+    }],
+    ['updateOrganization', 200, {
+        orgId: 'org-1', orgName: 'Acme', businessOwner: 'Jane', businessOwnerContact: '+1',
+        businessOwnerEmail: 'jane@acme.example', orgHandle: 'acme',
+        roleClaimName: 'roles', groupsClaimName: 'groups',
+        organizationClaimName: 'organizationIdentifier', organizationIdentifier: 'ACME',
+        adminRole: 'admin', subscriberRole: 'sub', superAdminRole: 'super',
+        orgConfiguration: {},
+    }],
+
+    // Identity Providers — IdentityProviderDTO output (src/dto/identityProvider.js)
+    ['createIdentityProvider', 201, {
+        name: 'IS', issuer: 'https://idp/iss', authorizationURL: 'https://idp/auth',
+        tokenURL: 'https://idp/token', clientId: 'cid', callbackURL: 'http://cb',
+        scope: 'openid', logoutURL: 'http://lo', logoutRedirectURI: 'http://lr',
+        userInfoURL: 'http://ui',
+    }],
+    ['updateIdentityProvider', 200, {
+        name: 'IS', issuer: 'https://idp/iss', authorizationURL: 'https://idp/auth',
+        tokenURL: 'https://idp/token', clientId: 'cid', callbackURL: 'http://cb',
+        scope: 'openid', logoutURL: 'http://lo', logoutRedirectURI: 'http://lr',
+    }],
+    ['getIdentityProvider', 200, {
+        name: 'IS', issuer: 'https://idp/iss', authorizationURL: 'https://idp/auth',
+        tokenURL: 'https://idp/token', clientId: 'cid', callbackURL: 'http://cb',
+        scope: 'openid', logoutURL: 'http://lo', logoutRedirectURI: 'http://lr',
+    }],
+
+    // Org content — adminService.createOrgContent L402, updateOrgContent L488 (both 201)
+    ['createOrgContent', 201, { orgId: 'org-1', fileName: 'theme.zip' }],
+    ['updateOrgContent', 201, { orgId: 'org-1', fileName: 'theme.zip' }],
+    ['getOrgLayoutContentByFileType', 200, [
+        { orgId: 'org-1', fileName: 'main.css', fileContent: 'body{}' },
+    ]],
+
+    // Providers — adminService.createProvider L599 emits providerData object
+    ['createProvider', 201, { orgId: 'org-1', name: 'WSO2', providerURL: 'https://wso2.com' }],
+    ['updateProvider', 200, { orgId: 'org-1', name: 'WSO2', providerURL: 'https://wso2.com' }],
+    ['getProviders', 200, [{ name: 'WSO2', providerURL: 'https://wso2.com' }]],
+
+    // Subscriptions — adminService.createSubscription L954 emits {message}
+    ['createSubscription', 200, { message: 'Subscribed successfully' }],
+    ['updateSubscription', 201, { message: 'Updated subscription successfully' }],
+
+    // Labels — service emits LabelDTO[] = [{name, displayName}]
+    ['retrieveLabels', 200, [
+        { name: 'premium', displayName: 'Premium APIs' },
+        { name: 'internal', displayName: 'Internal APIs' },
+    ]],
+    // createLabels echoes req.body — clients send LabelRequest[]
+    ['createLabels', 201, [{ name: 'premium', displayName: 'Premium APIs' }]],
+
+    // Subscription Policies — single-create returns DTO; bulk-disabled returns {message}
+    ['addSubscriptionPolicies', 201, {
+        policyID: 'p1', policyName: 'Bronze', displayName: 'Bronze',
+        billingPlan: 'FREE', description: 'desc', requestCount: 100,
+        orgID: 'org-1', pricingModel: 'flat', currency: 'usd',
+        billingPeriod: 'month', flatAmount: 0, unitAmount: 0, pricingMetadata: {},
+    }],
+    ['addSubscriptionPolicies', 200, { message: 'Bulk creation disabled' }],
+
+    // API Flows — apiFlowService.createAPIFlow L207 emits {apiFlowId, name, status}
+    ['createAPIFlow', 201, { apiFlowId: 'f1', name: 'flow1', status: 'PUBLISHED' }],
+    ['getAllAPIFlows', 200, [{
+        apiFlowId: 'f1', name: 'flow1', handle: 'flow-1', description: 'desc',
+        agentPrompt: 'prompt', status: 'PUBLISHED', visibility: 'PUBLIC',
+        agentVisibility: 'VISIBLE', contentType: 'ARAZZO',
+        apiFlowDefinition: '{}', markdownContent: null,
+        createdAt: 'May 7, 2026', updatedAt: '2026-05-07T08:30:00Z',
+    }]],
+
+    // Billing engine keys — billingController L557 emits 4-field shape
+    ['getBillingEngineKeys', 200, {
+        billingEngine: 'STRIPE', secretKey: '****',
+        publishableKey: '****', webhookSecret: '****',
+    }],
+    ['addBillingEngineKeys', 201, { message: 'Billing engine keys saved' }],
+    ['updateBillingEngineKeys', 200, { message: 'Billing engine keys updated' }],
+    ['deleteBillingEngineKeys', 200, { message: 'Billing engine keys deleted' }],
+];
+
+const drifts = [];
+for (const [opId, status, sample] of SAMPLES) {
+    const schema = responseSchema(opId, status);
+    if (!schema) {
+        console.log('SKIP   ' + opId + ' ' + status + '  (no spec response found at this status)');
+        continue;
+    }
+    if (schema.plainText) {
+        console.log('skip   ' + opId + ' ' + status + '  (plain-text response in spec)');
+        continue;
+    }
+    const r = validate(schema, sample);
+    if (r.ok) {
+        console.log('ok     ' + opId + ' ' + status);
+    } else {
+        console.log('DRIFT  ' + opId + ' ' + status);
+        for (const e of r.errors) {
+            const where = e.dataPath || e.instancePath || '';
+            const params = e.params ? '  ' + JSON.stringify(e.params) : '';
+            console.log('         ' + where + ' :: ' + e.message + params);
+        }
+        drifts.push({ opId, status, errors: r.errors });
+    }
+}
+
+console.log('---');
+console.log('drift items:', drifts.length, 'of', SAMPLES.length, 'samples');
+process.exit(drifts.length > 0 ? 1 : 0);

--- a/scripts/drift_check.js
+++ b/scripts/drift_check.js
@@ -1,4 +1,22 @@
 /*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+/*
  * Spec ↔ service response drift checker.
  *
  * Validates representative response payloads (drawn directly from service code)

--- a/src/app.js
+++ b/src/app.js
@@ -607,7 +607,13 @@ app.use((req, res, next) => {
 });
 
 //backend routes
-app.use(constants.ROUTE.DEV_PORTAL, devportalRoute);
+if (config.advanced?.useOpenApiValidator) {
+    logger.info('Mounting spec-driven /devportal router (advanced.useOpenApiValidator=true)');
+    const devportalApiRouter = require('./openapi/devportalApiRouter');
+    app.use(constants.ROUTE.DEV_PORTAL, devportalApiRouter);
+} else {
+    app.use(constants.ROUTE.DEV_PORTAL, devportalRoute);
+}
 
 // MCP Server Registry (OpenAPI v0.1)
 app.use('/registry/:orgHandle', mcpRegistryRoute);

--- a/src/app.js
+++ b/src/app.js
@@ -607,7 +607,7 @@ app.use((req, res, next) => {
 });
 
 //backend routes
-if (config.advanced?.useOpenApiValidator) {
+if (config.advanced?.openApiValidator?.enabled) {
     logger.info('Mounting spec-driven /devportal router (advanced.useOpenApiValidator=true)');
     const devportalApiRouter = require('./openapi/devportalApiRouter');
     app.use(constants.ROUTE.DEV_PORTAL, devportalApiRouter);

--- a/src/openapi/devportalApiRouter.js
+++ b/src/openapi/devportalApiRouter.js
@@ -92,6 +92,36 @@ function operationResolver(handlersPath, route, apiDoc) {
     return handler;
 }
 
+/**
+ * Resolve the response-validation strategy from config.
+ *
+ *   advanced.openApiValidator.validateResponses:
+ *     - false        → off (default in production)
+ *     - true         → strict — validator throws 500 on response drift
+ *     - 'log-only'   → log drift via logger.warn but pass the response through
+ *     - (unset)      → on iff config.mode === 'development'
+ *
+ * Use 'log-only' to surface drift in staging/QA without breaking clients.
+ */
+function resolveValidateResponsesOpt() {
+    const cfg = config.advanced?.openApiValidator?.validateResponses;
+    if (cfg === true) return true;
+    if (cfg === false) return false;
+    if (cfg === 'log-only' || cfg === 'logOnly') {
+        return {
+            onError: (err, json, req) => {
+                logger.warn('OpenAPI response drift (log-only)', {
+                    error: err.message,
+                    url: req.originalUrl,
+                    method: req.method,
+                    errors: err.errors,
+                });
+            },
+        };
+    }
+    return config.mode === constants.DEV_MODE;
+}
+
 function build() {
     const router = express.Router();
 
@@ -103,10 +133,7 @@ function build() {
         OpenApiValidator.middleware({
             apiSpec: SPEC_PATH,
             validateRequests: { allowUnknownQueryParameters: false },
-            // Response validation is noisy in production where some legacy
-            // services emit slightly off-spec shapes. Turn on in development
-            // so drift surfaces during local work.
-            validateResponses: config.mode === constants.DEV_MODE,
+            validateResponses: resolveValidateResponsesOpt(),
             validateSecurity: {
                 handlers: { OAuth2Security, apiKeyAuth },
             },

--- a/src/openapi/devportalApiRouter.js
+++ b/src/openapi/devportalApiRouter.js
@@ -79,6 +79,12 @@ function notImplementedHandler(operationId, tag) {
     };
 }
 
+function isMissingHandlerModule(err, modulePath) {
+    if (err.code !== 'MODULE_NOT_FOUND') return false;
+    const firstLine = String(err.message || '').split('\n')[0];
+    return firstLine === `Cannot find module '${modulePath}'`;
+}
+
 function operationResolver(handlersPath, route, apiDoc) {
     const pathKey = route.openApiRoute.substring(route.basePath.length);
     const schema = apiDoc.paths[pathKey][route.method.toLowerCase()];
@@ -91,7 +97,7 @@ function operationResolver(handlersPath, route, apiDoc) {
     try {
         mod = require(modulePath);
     } catch (err) {
-        if (err.code === 'MODULE_NOT_FOUND') {
+        if (isMissingHandlerModule(err, modulePath)) {
             return notImplementedHandler(operationId, tag);
         }
         throw err;

--- a/src/openapi/devportalApiRouter.js
+++ b/src/openapi/devportalApiRouter.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ */
+
+/*
+ * Spec-driven /devportal router.
+ *
+ * Wires the OpenAPI spec at docs/devportal-openapi-spec-v1.yaml into the
+ * Express app. Pipeline per request:
+ *
+ *   1. authResolver        — populates req.auth (legacy auth-mode parity)
+ *   2. OpenApiValidator    — request schema check + security handler dispatch
+ *                            + operationId-based handler routing
+ *   3. operation handler   — thin shim from src/openapi/handlers/<tag>.js
+ *
+ * Operations whose tag has no handler module yet, or whose operationId is
+ * not exported by the matching module, fall through to a 501 stub. This is
+ * intentional for the phased migration: routes can light up tag-by-tag
+ * without forcing a big-bang cut-over.
+ *
+ * Toggle off by setting `advanced.useOpenApiValidator: false` to fall back
+ * to src/routes/devportalRoute.js.
+ */
+
+const path = require('path');
+const express = require('express');
+const OpenApiValidator = require('express-openapi-validator');
+
+const { config } = require('../config/configLoader');
+const constants = require('../utils/constants');
+const logger = require('../config/logger');
+const { authResolver, OAuth2Security, apiKeyAuth } = require('./middleware/auth');
+
+const SPEC_PATH = path.join(__dirname, '..', '..', 'docs', 'devportal-openapi-spec-v1.yaml');
+const HANDLERS_DIR = path.join(__dirname, 'handlers');
+
+// Map an OpenAPI tag like "Identity Providers" to a handler-file basename
+// like "identityProviders".
+function tagToFileName(tag) {
+    const words = String(tag).trim().split(/\s+/).filter(Boolean);
+    if (words.length === 0) return 'misc';
+    return words
+        .map((w, i) => {
+            const lower = w.toLowerCase();
+            if (i === 0) return lower;
+            return lower.charAt(0).toUpperCase() + lower.slice(1);
+        })
+        .join('');
+}
+
+function notImplementedHandler(operationId, tag) {
+    return (req, res) => {
+        logger.warn('OpenAPI router: operation not yet wired in new path', {
+            operationId,
+            tag,
+            method: req.method,
+            url: req.originalUrl,
+        });
+        res.status(501).json({
+            code: 501,
+            message: 'Not Implemented',
+            description:
+                `Operation '${operationId}' (tag '${tag}') has no handler in src/openapi/handlers. ` +
+                `Set advanced.useOpenApiValidator=false to use the legacy /devportal route while migration is in progress.`,
+        });
+    };
+}
+
+function operationResolver(handlersPath, route, apiDoc) {
+    const pathKey = route.openApiRoute.substring(route.basePath.length);
+    const schema = apiDoc.paths[pathKey][route.method.toLowerCase()];
+    const operationId = schema.operationId;
+    const tag = (schema.tags && schema.tags[0]) || 'Misc';
+    const fileBase = tagToFileName(tag);
+    const modulePath = path.join(handlersPath, `${fileBase}.js`);
+
+    let mod;
+    try {
+        mod = require(modulePath);
+    } catch (err) {
+        if (err.code === 'MODULE_NOT_FOUND') {
+            return notImplementedHandler(operationId, tag);
+        }
+        throw err;
+    }
+    const handler = mod[operationId];
+    if (typeof handler !== 'function') {
+        return notImplementedHandler(operationId, tag);
+    }
+    return handler;
+}
+
+function build() {
+    const router = express.Router();
+
+    // Pre-validator: resolve credentials so OAuth2Security/apiKeyAuth handlers
+    // see a populated req.auth.
+    router.use(authResolver);
+
+    router.use(
+        OpenApiValidator.middleware({
+            apiSpec: SPEC_PATH,
+            validateRequests: { allowUnknownQueryParameters: false },
+            // Response validation is noisy in production where some legacy
+            // services emit slightly off-spec shapes. Turn on in development
+            // so drift surfaces during local work.
+            validateResponses: config.mode === constants.DEV_MODE,
+            validateSecurity: {
+                handlers: { OAuth2Security, apiKeyAuth },
+            },
+            operationHandlers: {
+                basePath: HANDLERS_DIR,
+                resolver: operationResolver,
+            },
+            // Multipart endpoints in the spec (org content upload, API
+            // metadata upload, etc.) are handled by the validator's built-in
+            // multer. Disk storage matches the legacy multer config.
+            fileUploader: { dest: require('os').tmpdir() },
+            // Format strictness — use 'fast' for runtime cost; 'full' is too
+            // strict for some of our existing schemas (e.g. uri formats).
+            validateFormats: 'fast',
+        })
+    );
+
+    // Translate validator errors and security-handler thrown errors into the
+    // JSON envelope the rest of the portal returns. The validator throws
+    // objects with { status, message, errors? }.
+    router.use((err, req, res, next) => {
+        if (res.headersSent) return next(err);
+        const status = err.status || 500;
+        if (status >= 500) {
+            logger.error('OpenAPI router error', {
+                error: err.message,
+                stack: err.stack,
+                url: req.originalUrl,
+                method: req.method,
+            });
+        } else {
+            logger.warn('OpenAPI router rejected request', {
+                error: err.message,
+                status,
+                url: req.originalUrl,
+                method: req.method,
+            });
+        }
+        res.status(status).json({
+            code: status,
+            message: err.message || 'Request failed',
+            errors: err.errors,
+        });
+    });
+
+    return router;
+}
+
+module.exports = build();

--- a/src/openapi/devportalApiRouter.js
+++ b/src/openapi/devportalApiRouter.js
@@ -1,7 +1,20 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License").
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
 /*
@@ -20,8 +33,6 @@
  * intentional for the phased migration: routes can light up tag-by-tag
  * without forcing a big-bang cut-over.
  *
- * Toggle off by setting `advanced.useOpenApiValidator: false` to fall back
- * to src/routes/devportalRoute.js.
  */
 
 const path = require('path');
@@ -126,7 +137,6 @@ function build() {
     const router = express.Router();
 
     // Pre-validator: resolve credentials so OAuth2Security/apiKeyAuth handlers
-    // see a populated req.auth.
     router.use(authResolver);
 
     router.use(

--- a/src/openapi/devportalApiRouter.js
+++ b/src/openapi/devportalApiRouter.js
@@ -121,7 +121,7 @@ function operationResolver(handlersPath, route, apiDoc) {
  * Use 'log-only' to surface drift in staging/QA without breaking clients.
  */
 function resolveValidateResponsesOpt() {
-    const cfg = config.advanced?.openApiValidator?.validateResponses;
+    const cfg = config.advanced?.openApiValidator?.openApiValidator?.validateResponses;
     if (cfg === true) return true;
     if (cfg === false) return false;
     if (cfg === 'log-only' || cfg === 'logOnly') {

--- a/src/openapi/devportalApiRouter.js
+++ b/src/openapi/devportalApiRouter.js
@@ -122,8 +122,8 @@ function operationResolver(handlersPath, route, apiDoc) {
  */
 function resolveValidateResponsesOpt() {
     const cfg = config.advanced?.openApiValidator?.openApiValidator?.validateResponses;
-    if (cfg === true) return true;
-    if (cfg === false) return false;
+    if (cfg === 'strict') return true;
+    if (cfg === 'off') return false;
     if (cfg === 'log-only' || cfg === 'logOnly') {
         return {
             onError: (err, json, req) => {

--- a/src/openapi/handlers/_compose.js
+++ b/src/openapi/handlers/_compose.js
@@ -1,17 +1,24 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License").
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
 /*
  * Tiny middleware-chain helper for OpenAPI operation handlers.
- *
- * The validator's operationHandlers resolver returns a single handler per
- * operation. Some operations need extra middleware (CSRF protection, billing
- * auth, request-origin verification) before the service function. Use
- * `compose(...)` to produce a single Express handler that runs each
- * middleware in order, short-circuiting on error.
  *
  * Example:
  *   const platformApiKeyService = require('../../services/platformApiKeyService');

--- a/src/openapi/handlers/_compose.js
+++ b/src/openapi/handlers/_compose.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ */
+
+/*
+ * Tiny middleware-chain helper for OpenAPI operation handlers.
+ *
+ * The validator's operationHandlers resolver returns a single handler per
+ * operation. Some operations need extra middleware (CSRF protection, billing
+ * auth, request-origin verification) before the service function. Use
+ * `compose(...)` to produce a single Express handler that runs each
+ * middleware in order, short-circuiting on error.
+ *
+ * Example:
+ *   const platformApiKeyService = require('../../services/platformApiKeyService');
+ *   const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection');
+ *   exports.generatePlatformApiKey = compose(
+ *       requireCsrfForMutatingApi,
+ *       platformApiKeyService.generatePlatformApiKey
+ *   );
+ */
+
+function compose(...fns) {
+    const stack = fns.flat().filter(fn => typeof fn === 'function');
+    return function composed(req, res, next) {
+        let i = 0;
+        const run = (err) => {
+            if (err) return next(err);
+            if (res.headersSent) return;
+            const fn = stack[i++];
+            if (!fn) return next();
+            try {
+                const ret = fn(req, res, run);
+                if (ret && typeof ret.catch === 'function') ret.catch(run);
+            } catch (e) {
+                run(e);
+            }
+        };
+        run();
+    };
+}
+
+module.exports = { compose };

--- a/src/openapi/handlers/apiContent.js
+++ b/src/openapi/handlers/apiContent.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: API Content
+ *
+ * Drift fix-up:
+ *   spec  getAPIContentFile     →  service  getAPIFile
+ *   spec  deleteAPIContentFile  →  service  deleteAPIFile
+ */
+
+const apiMetadataService = require('../../services/apiMetadataService');
+
+module.exports = {
+    createAPIContent: apiMetadataService.createAPIContent,
+    updateAPIContent: apiMetadataService.updateAPIContent,
+    getAPIContentFile: apiMetadataService.getAPIFile,
+    deleteAPIContentFile: apiMetadataService.deleteAPIFile,
+};

--- a/src/openapi/handlers/apiContent.js
+++ b/src/openapi/handlers/apiContent.js
@@ -1,14 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: API Content
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Drift fix-up:
- *   spec  getAPIContentFile     →  service  getAPIFile
- *   spec  deleteAPIContentFile  →  service  deleteAPIFile
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: API Content
+ */
 const apiMetadataService = require('../../services/apiMetadataService');
 
 module.exports = {

--- a/src/openapi/handlers/apiFlows.js
+++ b/src/openapi/handlers/apiFlows.js
@@ -1,10 +1,26 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/*
  * Tag: API Flows
  *
- * Mutating ops are CSRF-protected (matches legacy devportalRoute.js).
+ * Mutating ops are CSRF-protected with compose(requireCsrfForMutatingApi, serviceFn). Non-mutating ops are just serviceFn.
  */
 
 const apiFlowService = require('../../services/apiFlowService');

--- a/src/openapi/handlers/apiFlows.js
+++ b/src/openapi/handlers/apiFlows.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: API Flows
+ *
+ * Mutating ops are CSRF-protected (matches legacy devportalRoute.js).
+ */
+
+const apiFlowService = require('../../services/apiFlowService');
+const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection');
+const { compose } = require('./_compose');
+
+module.exports = {
+    createAPIFlow: compose(requireCsrfForMutatingApi, apiFlowService.createAPIFlow),
+    getAllAPIFlows: apiFlowService.getAllAPIFlows,
+    getAPIFlow: apiFlowService.getAPIFlow,
+    updateAPIFlow: compose(requireCsrfForMutatingApi, apiFlowService.updateAPIFlow),
+    deleteAPIFlow: compose(requireCsrfForMutatingApi, apiFlowService.deleteAPIFlow),
+    generatePrompt: compose(requireCsrfForMutatingApi, apiFlowService.generatePrompt),
+};

--- a/src/openapi/handlers/apis.js
+++ b/src/openapi/handlers/apis.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: APIs
+ *
+ * Drift fix-up:
+ *   spec  getAllAPIMetadataForOrganization  →  service  getAllAPIMetadata
+ *
+ * The legacy s2s `/apis` (no orgId) routes are NOT part of this spec; clients
+ * that depend on them must use the legacy router (advanced.useOpenApiValidator=false).
+ *
+ * Spec also no longer exposes the legacy `/template` API content routes —
+ * only `/content`. /template clients must use the legacy path.
+ */
+
+const apiMetadataService = require('../../services/apiMetadataService');
+
+module.exports = {
+    createAPIMetadata: apiMetadataService.createAPIMetadata,
+    getAPIMetadata: apiMetadataService.getAPIMetadata,
+    getAllAPIMetadataForOrganization: apiMetadataService.getAllAPIMetadata,
+    updateAPIMetadata: apiMetadataService.updateAPIMetadata,
+    deleteAPIMetadata: apiMetadataService.deleteAPIMetadata,
+};

--- a/src/openapi/handlers/apis.js
+++ b/src/openapi/handlers/apis.js
@@ -1,19 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: APIs
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Drift fix-up:
- *   spec  getAllAPIMetadataForOrganization  →  service  getAllAPIMetadata
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * The legacy s2s `/apis` (no orgId) routes are NOT part of this spec; clients
- * that depend on them must use the legacy router (advanced.useOpenApiValidator=false).
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  *
- * Spec also no longer exposes the legacy `/template` API content routes —
- * only `/content`. /template clients must use the legacy path.
  */
 
+/*
+ * Tag: APIs
+ */
 const apiMetadataService = require('../../services/apiMetadataService');
 
 module.exports = {

--- a/src/openapi/handlers/appKeyMapping.js
+++ b/src/openapi/handlers/appKeyMapping.js
@@ -1,13 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: App Key Mapping
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Drift fix-up:
- *   spec  retrieveAppKeyMappings  →  service  retriveAppKeyMappings  (typo in service)
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: App Key Mapping
+ */
 const adminService = require('../../services/adminService');
 
 module.exports = {

--- a/src/openapi/handlers/appKeyMapping.js
+++ b/src/openapi/handlers/appKeyMapping.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: App Key Mapping
+ *
+ * Drift fix-up:
+ *   spec  retrieveAppKeyMappings  →  service  retriveAppKeyMappings  (typo in service)
+ */
+
+const adminService = require('../../services/adminService');
+
+module.exports = {
+    createAppKeyMapping: adminService.createAppKeyMapping,
+    retrieveAppKeyMappings: adminService.retriveAppKeyMappings,
+};

--- a/src/openapi/handlers/applicationKeys.js
+++ b/src/openapi/handlers/applicationKeys.js
@@ -1,16 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Application Keys
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Drift fix-up:
- *   spec  cleanUpOAuthKeys           →  service  cleanUp
- *   spec  generateApplicationAPIKeys →  service  generateAPIKeys
- *     (the application-scoped variant; the unscoped /api-keys/generate is
- *      the same service function under the spec's `generateAPIKeys` opId)
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Application Keys
+ */
 const devportalController = require('../../controllers/devportalController');
 
 module.exports = {

--- a/src/openapi/handlers/applicationKeys.js
+++ b/src/openapi/handlers/applicationKeys.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Application Keys
+ *
+ * Drift fix-up:
+ *   spec  cleanUpOAuthKeys           →  service  cleanUp
+ *   spec  generateApplicationAPIKeys →  service  generateAPIKeys
+ *     (the application-scoped variant; the unscoped /api-keys/generate is
+ *      the same service function under the spec's `generateAPIKeys` opId)
+ */
+
+const devportalController = require('../../controllers/devportalController');
+
+module.exports = {
+    generateApplicationAPIKeys: devportalController.generateAPIKeys,
+    generateApplicationKeys: devportalController.generateApplicationKeys,
+    generateOAuthKeys: devportalController.generateOAuthKeys,
+    revokeOAuthKeys: devportalController.revokeOAuthKeys,
+    updateOAuthKeys: devportalController.updateOAuthKeys,
+    cleanUpOAuthKeys: devportalController.cleanUp,
+    generateAPIKeys: devportalController.generateAPIKeys,
+    revokeAPIKeys: devportalController.revokeAPIKeys,
+    regenerateAPIKeys: devportalController.regenerateAPIKeys,
+};

--- a/src/openapi/handlers/applications.js
+++ b/src/openapi/handlers/applications.js
@@ -20,4 +20,8 @@ module.exports = {
     getDevPortalApplications: adminService.getDevPortalApplications,
     deleteDevPortalApplication: adminService.deleteDevPortalApplication,
     importApplications: devportalController.importApplications,
+    saveApplication: devportalController.saveApplication,
+    updateApplication: devportalController.updateApplication,
+    deleteApplication: devportalController.deleteApplication,
+    resetThrottlingPolicy: devportalController.resetThrottlingPolicy,
 };

--- a/src/openapi/handlers/applications.js
+++ b/src/openapi/handlers/applications.js
@@ -1,15 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Applications
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * `importApplications` is feature-gated in the legacy router
- * (config.features.importApplication.enabled). The new router exposes the
- * route unconditionally; the controller itself can fail-fast if the feature
- * is disabled. Flag for follow-up if you want to preserve the gate.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Applications
+ */
 const adminService = require('../../services/adminService');
 const devportalController = require('../../controllers/devportalController');
 

--- a/src/openapi/handlers/applications.js
+++ b/src/openapi/handlers/applications.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Applications
+ *
+ * `importApplications` is feature-gated in the legacy router
+ * (config.features.importApplication.enabled). The new router exposes the
+ * route unconditionally; the controller itself can fail-fast if the feature
+ * is disabled. Flag for follow-up if you want to preserve the gate.
+ */
+
+const adminService = require('../../services/adminService');
+const devportalController = require('../../controllers/devportalController');
+
+module.exports = {
+    createDevPortalApplication: adminService.createDevPortalApplication,
+    updateDevPortalApplication: adminService.updateDevPortalApplication,
+    getDevPortalApplicationDetails: adminService.getDevPortalApplicationDetails,
+    getDevPortalApplications: adminService.getDevPortalApplications,
+    deleteDevPortalApplication: adminService.deleteDevPortalApplication,
+    importApplications: devportalController.importApplications,
+};

--- a/src/openapi/handlers/authentication.js
+++ b/src/openapi/handlers/authentication.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Authentication
+ */
+
+const devportalController = require('../../controllers/devportalController');
+
+module.exports = {
+    login: devportalController.login,
+};

--- a/src/openapi/handlers/authentication.js
+++ b/src/openapi/handlers/authentication.js
@@ -1,10 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Authentication
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Authentication
+ */
 const devportalController = require('../../controllers/devportalController');
 
 module.exports = {

--- a/src/openapi/handlers/billing.js
+++ b/src/openapi/handlers/billing.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Billing
+ *
+ * Mirrors the legacy devportalRoute.js middleware composition:
+ *   - read-only billing endpoints           : ensureBillingAuth
+ *   - mutating billing endpoints            : verifyRequestOrigin + ensureBillingAuth
+ *   - billing-engine-keys (admin config)    : verifyRequestOrigin (write) + (no ensureBillingAuth — uses OAuth scope only)
+ *
+ * The OAuth scope check itself runs in the OpenAPI validator's security
+ * pipeline; we only add the application-layer middleware here.
+ */
+
+const billingController = require('../../controllers/billingController');
+const { ensureBillingAuth, verifyRequestOrigin } = require('../../middlewares/billingAuth');
+const { compose } = require('./_compose');
+
+module.exports = {
+    // Read-only
+    getUsageData: compose(ensureBillingAuth, billingController.getUsageData),
+    getPaymentMethods: compose(ensureBillingAuth, billingController.getPaymentMethods),
+    getBillingInfo: compose(ensureBillingAuth, billingController.getBillingInfo),
+    getActiveSubscriptions: compose(ensureBillingAuth, billingController.getActiveSubscriptions),
+    getSubscriptionBillingStatus: compose(ensureBillingAuth, billingController.getSubscriptionBillingStatus),
+
+    // Billing engine keys (admin config; OAuth scope handles auth, origin verification on writes)
+    addBillingEngineKeys: compose(verifyRequestOrigin, billingController.addBillingEngineKeys),
+    updateBillingEngineKeys: compose(verifyRequestOrigin, billingController.updateBillingEngineKeys),
+    deleteBillingEngineKeys: compose(verifyRequestOrigin, billingController.deleteBillingEngineKeys),
+    getBillingEngineKeys: billingController.getBillingEngineKeys,
+
+    // Mutating Stripe / billing portal flows
+    createCheckoutSessionForSubscription: compose(verifyRequestOrigin, ensureBillingAuth, billingController.createCheckoutSessionForSubscription),
+    registerStripeCheckoutSession: compose(verifyRequestOrigin, ensureBillingAuth, billingController.registerStripeCheckoutSession),
+    cancelSubscription: compose(verifyRequestOrigin, ensureBillingAuth, billingController.cancelSubscription),
+    createBillingPortalByOrg: compose(verifyRequestOrigin, ensureBillingAuth, billingController.createBillingPortalByOrg),
+    createBillingPortal: compose(verifyRequestOrigin, ensureBillingAuth, billingController.createBillingPortal),
+};

--- a/src/openapi/handlers/billing.js
+++ b/src/openapi/handlers/billing.js
@@ -1,18 +1,26 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Billing
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Mirrors the legacy devportalRoute.js middleware composition:
- *   - read-only billing endpoints           : ensureBillingAuth
- *   - mutating billing endpoints            : verifyRequestOrigin + ensureBillingAuth
- *   - billing-engine-keys (admin config)    : verifyRequestOrigin (write) + (no ensureBillingAuth — uses OAuth scope only)
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * The OAuth scope check itself runs in the OpenAPI validator's security
- * pipeline; we only add the application-layer middleware here.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Billing
+ * Some are protected with csrfProtection middleware 
+ */
 const billingController = require('../../controllers/billingController');
 const { ensureBillingAuth, verifyRequestOrigin } = require('../../middlewares/billingAuth');
 const { compose } = require('./_compose');

--- a/src/openapi/handlers/identityProviders.js
+++ b/src/openapi/handlers/identityProviders.js
@@ -1,13 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License").
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
 /*
  * OpenAPI operation handlers for the Identity Providers tag.
  */
-
 const adminService = require('../../services/adminService');
 
 module.exports = {

--- a/src/openapi/handlers/identityProviders.js
+++ b/src/openapi/handlers/identityProviders.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ */
+
+/*
+ * OpenAPI operation handlers for the Identity Providers tag.
+ */
+
+const adminService = require('../../services/adminService');
+
+module.exports = {
+    createIdentityProvider: adminService.createIdentityProvider,
+    updateIdentityProvider: adminService.updateIdentityProvider,
+    getIdentityProvider: adminService.getIdentityProvider,
+    deleteIdentityProvider: adminService.deleteIdentityProvider,
+};

--- a/src/openapi/handlers/invoices.js
+++ b/src/openapi/handlers/invoices.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Invoices
+ */
+
+const invoiceController = require('../../controllers/invoiceController');
+const { ensureBillingAuth } = require('../../middlewares/billingAuth');
+const { compose } = require('./_compose');
+
+module.exports = {
+    listInvoices: compose(ensureBillingAuth, invoiceController.listInvoices),
+    getInvoice: compose(ensureBillingAuth, invoiceController.getInvoice),
+    listInvoicesBySubscription: compose(ensureBillingAuth, invoiceController.listInvoicesBySubscription),
+    getInvoicePdfLink: compose(ensureBillingAuth, invoiceController.getInvoicePdfLink),
+    redirectHostedInvoice: compose(ensureBillingAuth, invoiceController.redirectHostedInvoice),
+};

--- a/src/openapi/handlers/invoices.js
+++ b/src/openapi/handlers/invoices.js
@@ -1,10 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Invoices
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Invoices
+ */
 const invoiceController = require('../../controllers/invoiceController');
 const { ensureBillingAuth } = require('../../middlewares/billingAuth');
 const { compose } = require('./_compose');

--- a/src/openapi/handlers/labels.js
+++ b/src/openapi/handlers/labels.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Labels
+ */
+
+const apiMetadataService = require('../../services/apiMetadataService');
+
+module.exports = {
+    createLabels: apiMetadataService.createLabels,
+    updateLabel: apiMetadataService.updateLabel,
+    retrieveLabels: apiMetadataService.retrieveLabels,
+    deleteLabels: apiMetadataService.deleteLabels,
+};

--- a/src/openapi/handlers/labels.js
+++ b/src/openapi/handlers/labels.js
@@ -1,10 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Labels
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Labels
+ */
 const apiMetadataService = require('../../services/apiMetadataService');
 
 module.exports = {

--- a/src/openapi/handlers/organizationContent.js
+++ b/src/openapi/handlers/organizationContent.js
@@ -1,15 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Organization Content
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Note: spec defines getOrgLayoutContent + getOrgLayoutContentByFileType as
- * two separate operations, but the legacy service `devportalService.getOrgContent`
- * branches on `req.params.fileType` / `req.query.fileType` itself, so both
- * operationIds map to the same shim.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Organization Content
+ */
 const adminService = require('../../services/adminService');
 const devportalService = require('../../services/devportalService');
 

--- a/src/openapi/handlers/organizationContent.js
+++ b/src/openapi/handlers/organizationContent.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Organization Content
+ *
+ * Note: spec defines getOrgLayoutContent + getOrgLayoutContentByFileType as
+ * two separate operations, but the legacy service `devportalService.getOrgContent`
+ * branches on `req.params.fileType` / `req.query.fileType` itself, so both
+ * operationIds map to the same shim.
+ */
+
+const adminService = require('../../services/adminService');
+const devportalService = require('../../services/devportalService');
+
+module.exports = {
+    createOrgContent: adminService.createOrgContent,
+    updateOrgContent: adminService.updateOrgContent,
+    getOrgLayoutContent: devportalService.getOrgContent,
+    getOrgLayoutContentByFileType: devportalService.getOrgContent,
+    deleteOrgContent: adminService.deleteOrgContent,
+};

--- a/src/openapi/handlers/organizationContent.js
+++ b/src/openapi/handlers/organizationContent.js
@@ -22,13 +22,13 @@
  */
 const adminService = require('../../services/adminService');
 const devportalService = require('../../services/devportalService');
-const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection')
 const { compose } = require('./_compose');
 
 module.exports = {
-    createOrgContent: compose(requireCsrfMutatingApi, composeadminService.createOrgContent),
-    updateOrgContent: compose(requireCsrfMutatingApi, composeadminService.updateOrgContent),
+    createOrgContent: compose(requireCsrfForMutatingApi, adminService.createOrgContent),
+    updateOrgContent: compose(requireCsrfForMutatingApi, adminService.updateOrgContent),
     getOrgLayoutContent: devportalService.getOrgContent,
     getOrgLayoutContentByFileType: devportalService.getOrgContent,
-    deleteOrgContent: compose(requireCsrfMutatingApi, adminService.deleteOrgContent)
+    deleteOrgContent: compose(requireCsrfForMutatingApi, adminService.deleteOrgContent)
 };

--- a/src/openapi/handlers/organizationContent.js
+++ b/src/openapi/handlers/organizationContent.js
@@ -22,11 +22,13 @@
  */
 const adminService = require('../../services/adminService');
 const devportalService = require('../../services/devportalService');
+const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { compose } = require('./_compose');
 
 module.exports = {
-    createOrgContent: adminService.createOrgContent,
-    updateOrgContent: adminService.updateOrgContent,
+    createOrgContent: compose(requireCsrfMutatingApi, composeadminService.createOrgContent),
+    updateOrgContent: compose(requireCsrfMutatingApi, composeadminService.updateOrgContent),
     getOrgLayoutContent: devportalService.getOrgContent,
     getOrgLayoutContentByFileType: devportalService.getOrgContent,
-    deleteOrgContent: adminService.deleteOrgContent,
+    deleteOrgContent: compose(requireCsrfMutatingApi, adminService.deleteOrgContent)
 };

--- a/src/openapi/handlers/organizations.js
+++ b/src/openapi/handlers/organizations.js
@@ -1,16 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License").
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
 /*
  * OpenAPI operation handlers for the Organizations tag.
- * Each export is named after the spec `operationId`; the validator's
- * resolver dispatches by that name. Implementations delegate to the
- * existing services so business logic is not duplicated.
  */
-
 const adminService = require('../../services/adminService');
 const devportalService = require('../../services/devportalService');
 

--- a/src/openapi/handlers/organizations.js
+++ b/src/openapi/handlers/organizations.js
@@ -22,11 +22,13 @@
  */
 const adminService = require('../../services/adminService');
 const devportalService = require('../../services/devportalService');
+const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { compose } = require('./_compose');
 
 module.exports = {
-    createOrganization: adminService.createOrganization,
+    createOrganization: compose(requireCsrfMutatingApi, adminService.createOrganization),
     getOrganizations: adminService.getOrganizations,
-    updateOrganization: adminService.updateOrganization,
+    updateOrganization: compose(requireCsrfMutatingApi, adminService.updateOrganization),
     getOrganization: devportalService.getOrganization,
-    deleteOrganization: adminService.deleteOrganization,
+    deleteOrganization: compose(requireCsrfMutatingApi, adminService.deleteOrganization),
 };

--- a/src/openapi/handlers/organizations.js
+++ b/src/openapi/handlers/organizations.js
@@ -22,13 +22,13 @@
  */
 const adminService = require('../../services/adminService');
 const devportalService = require('../../services/devportalService');
-const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection')
 const { compose } = require('./_compose');
 
 module.exports = {
-    createOrganization: compose(requireCsrfMutatingApi, adminService.createOrganization),
+    createOrganization: compose(requireCsrfForMutatingApi, adminService.createOrganization),
     getOrganizations: adminService.getOrganizations,
-    updateOrganization: compose(requireCsrfMutatingApi, adminService.updateOrganization),
+    updateOrganization: compose(requireCsrfForMutatingApi, adminService.updateOrganization),
     getOrganization: devportalService.getOrganization,
-    deleteOrganization: compose(requireCsrfMutatingApi, adminService.deleteOrganization),
+    deleteOrganization: compose(requireCsrfForMutatingApi, adminService.deleteOrganization),
 };

--- a/src/openapi/handlers/organizations.js
+++ b/src/openapi/handlers/organizations.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ */
+
+/*
+ * OpenAPI operation handlers for the Organizations tag.
+ * Each export is named after the spec `operationId`; the validator's
+ * resolver dispatches by that name. Implementations delegate to the
+ * existing services so business logic is not duplicated.
+ */
+
+const adminService = require('../../services/adminService');
+const devportalService = require('../../services/devportalService');
+
+module.exports = {
+    createOrganization: adminService.createOrganization,
+    getOrganizations: adminService.getOrganizations,
+    updateOrganization: adminService.updateOrganization,
+    getOrganization: devportalService.getOrganization,
+    deleteOrganization: adminService.deleteOrganization,
+};

--- a/src/openapi/handlers/platformApiKeys.js
+++ b/src/openapi/handlers/platformApiKeys.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Platform API Keys
+ *
+ * Mutating ops are CSRF-protected (matches legacy devportalRoute.js).
+ */
+
+const platformApiKeyService = require('../../services/platformApiKeyService');
+const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection');
+const { compose } = require('./_compose');
+
+module.exports = {
+    generatePlatformApiKey: compose(requireCsrfForMutatingApi, platformApiKeyService.generatePlatformApiKey),
+    listPlatformApiKeys: platformApiKeyService.listPlatformApiKeys,
+    regeneratePlatformApiKey: compose(requireCsrfForMutatingApi, platformApiKeyService.regeneratePlatformApiKey),
+    revokePlatformApiKey: compose(requireCsrfForMutatingApi, platformApiKeyService.revokePlatformApiKey),
+};

--- a/src/openapi/handlers/platformApiKeys.js
+++ b/src/openapi/handlers/platformApiKeys.js
@@ -1,12 +1,27 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/*
  * Tag: Platform API Keys
  *
  * Mutating ops are CSRF-protected (matches legacy devportalRoute.js).
  */
-
 const platformApiKeyService = require('../../services/platformApiKeyService');
 const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection');
 const { compose } = require('./_compose');

--- a/src/openapi/handlers/platformSubscriptions.js
+++ b/src/openapi/handlers/platformSubscriptions.js
@@ -21,13 +21,13 @@
  * Tag: Platform Subscriptions
  */
 const platformSubscriptionService = require('../../services/platformSubscriptionService');
-const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection')
 const { compose } = require('./_compose');
 
 module.exports = {
-    createPlatformGatewaySubscription: compose(requireCsrfMutatingApi, platformSubscriptionService.createPlatformGatewaySubscription),
+    createPlatformGatewaySubscription: compose(requireCsrfForMutatingApi, platformSubscriptionService.createPlatformGatewaySubscription),
     listPlatformGatewaySubscriptions: platformSubscriptionService.listPlatformGatewaySubscriptions,
     getPlatformGatewaySubscription: platformSubscriptionService.getPlatformGatewaySubscription,
-    updatePlatformGatewaySubscription: compose(requireCsrfMutatingApi, platformSubscriptionService.updatePlatformGatewaySubscription),
-    deletePlatformGatewaySubscription: compose(requireCsrfMutatingApi, platformSubscriptionService.deletePlatformGatewaySubscription),
+    updatePlatformGatewaySubscription: compose(requireCsrfForMutatingApi, platformSubscriptionService.updatePlatformGatewaySubscription),
+    deletePlatformGatewaySubscription: compose(requireCsrfForMutatingApi, platformSubscriptionService.deletePlatformGatewaySubscription),
 };

--- a/src/openapi/handlers/platformSubscriptions.js
+++ b/src/openapi/handlers/platformSubscriptions.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Platform Subscriptions
+ */
+
+const platformSubscriptionService = require('../../services/platformSubscriptionService');
+
+module.exports = {
+    createPlatformGatewaySubscription: platformSubscriptionService.createPlatformGatewaySubscription,
+    listPlatformGatewaySubscriptions: platformSubscriptionService.listPlatformGatewaySubscriptions,
+    getPlatformGatewaySubscription: platformSubscriptionService.getPlatformGatewaySubscription,
+    updatePlatformGatewaySubscription: platformSubscriptionService.updatePlatformGatewaySubscription,
+    deletePlatformGatewaySubscription: platformSubscriptionService.deletePlatformGatewaySubscription,
+};

--- a/src/openapi/handlers/platformSubscriptions.js
+++ b/src/openapi/handlers/platformSubscriptions.js
@@ -1,10 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Platform Subscriptions
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Platform Subscriptions
+ */
 const platformSubscriptionService = require('../../services/platformSubscriptionService');
 
 module.exports = {

--- a/src/openapi/handlers/platformSubscriptions.js
+++ b/src/openapi/handlers/platformSubscriptions.js
@@ -21,11 +21,13 @@
  * Tag: Platform Subscriptions
  */
 const platformSubscriptionService = require('../../services/platformSubscriptionService');
+const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { compose } = require('./_compose');
 
 module.exports = {
-    createPlatformGatewaySubscription: platformSubscriptionService.createPlatformGatewaySubscription,
+    createPlatformGatewaySubscription: compose(requireCsrfMutatingApi, platformSubscriptionService.createPlatformGatewaySubscription),
     listPlatformGatewaySubscriptions: platformSubscriptionService.listPlatformGatewaySubscriptions,
     getPlatformGatewaySubscription: platformSubscriptionService.getPlatformGatewaySubscription,
-    updatePlatformGatewaySubscription: platformSubscriptionService.updatePlatformGatewaySubscription,
-    deletePlatformGatewaySubscription: platformSubscriptionService.deletePlatformGatewaySubscription,
+    updatePlatformGatewaySubscription: compose(requireCsrfMutatingApi, platformSubscriptionService.updatePlatformGatewaySubscription),
+    deletePlatformGatewaySubscription: compose(requireCsrfMutatingApi, platformSubscriptionService.deletePlatformGatewaySubscription),
 };

--- a/src/openapi/handlers/providers.js
+++ b/src/openapi/handlers/providers.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Providers
+ */
+
+const adminService = require('../../services/adminService');
+
+module.exports = {
+    createProvider: adminService.createProvider,
+    updateProvider: adminService.updateProvider,
+    getProviders: adminService.getProviders,
+    deleteProvider: adminService.deleteProvider,
+};

--- a/src/openapi/handlers/providers.js
+++ b/src/openapi/handlers/providers.js
@@ -1,10 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Providers
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Providers
+ */
 const adminService = require('../../services/adminService');
 
 module.exports = {

--- a/src/openapi/handlers/providers.js
+++ b/src/openapi/handlers/providers.js
@@ -21,12 +21,12 @@
  * Tag: Providers
  */
 const adminService = require('../../services/adminService');
-const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection')
 const { compose } = require('./_compose');
 
 module.exports = {
-    createProvider: compose(requireCsrfMutatingApi, adminService.createProvider),
-    updateProvider: compose(requireCsrfMutatingApi, adminService.updateProvider),
+    createProvider: compose(requireCsrfForMutatingApi, adminService.createProvider),
+    updateProvider: compose(requireCsrfForMutatingApi, adminService.updateProvider),
     getProviders: adminService.getProviders,
-    deleteProvider: compose(requireCsrfMutatingApi, adminService.deleteProvider),
+    deleteProvider: compose(requireCsrfForMutatingApi, adminService.deleteProvider),
 };

--- a/src/openapi/handlers/providers.js
+++ b/src/openapi/handlers/providers.js
@@ -21,10 +21,12 @@
  * Tag: Providers
  */
 const adminService = require('../../services/adminService');
+const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { compose } = require('./_compose');
 
 module.exports = {
-    createProvider: adminService.createProvider,
-    updateProvider: adminService.updateProvider,
+    createProvider: compose(requireCsrfMutatingApi, adminService.createProvider),
+    updateProvider: compose(requireCsrfMutatingApi, adminService.updateProvider),
     getProviders: adminService.getProviders,
-    deleteProvider: adminService.deleteProvider,
+    deleteProvider: compose(requireCsrfMutatingApi, adminService.deleteProvider),
 };

--- a/src/openapi/handlers/sdk.js
+++ b/src/openapi/handlers/sdk.js
@@ -21,10 +21,12 @@
  * Tag: SDK
  */
 const sdkJobService = require('../../services/sdkJobService');
+const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection')
+const { compose } = require('./_compose');
 
 module.exports = {
-    generateSDK: sdkJobService.generateSDK,
+    generateSDK: compose(requireCsrfForMutatingApi, sdkJobService.generateSDK),
     streamSDKProgress: sdkJobService.streamSDKProgress,
-    cancelSDK: sdkJobService.cancelSDK,
+    cancelSDK: compose(requireCsrfForMutatingApi, sdkJobService.cancelSDK),
     downloadSDK: sdkJobService.downloadSDK,
 };

--- a/src/openapi/handlers/sdk.js
+++ b/src/openapi/handlers/sdk.js
@@ -1,10 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: SDK
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: SDK
+ */
 const sdkJobService = require('../../services/sdkJobService');
 
 module.exports = {

--- a/src/openapi/handlers/sdk.js
+++ b/src/openapi/handlers/sdk.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: SDK
+ */
+
+const sdkJobService = require('../../services/sdkJobService');
+
+module.exports = {
+    generateSDK: sdkJobService.generateSDK,
+    streamSDKProgress: sdkJobService.streamSDKProgress,
+    cancelSDK: sdkJobService.cancelSDK,
+    downloadSDK: sdkJobService.downloadSDK,
+};

--- a/src/openapi/handlers/subscriptionPolicies.js
+++ b/src/openapi/handlers/subscriptionPolicies.js
@@ -21,10 +21,12 @@
  * Tag: Subscription Policies
  */
 const apiMetadataService = require('../../services/apiMetadataService');
+const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { compose } = require('./_compose');
 
 module.exports = {
-    addSubscriptionPolicies: apiMetadataService.addSubscriptionPolicies,
-    putSubscriptionPolicies: apiMetadataService.putSubscriptionPolicies,
+    addSubscriptionPolicies: compose(requireCsrfMutatingApi, apiMetadataService.addSubscriptionPolicies),
+    putSubscriptionPolicies: compose(requireCsrfMutatingApi, apiMetadataService.putSubscriptionPolicies),
     getSubscriptionPolicy: apiMetadataService.getSubscriptionPolicy,
-    deleteSubscriptionPolicy: apiMetadataService.deleteSubscriptionPolicy,
+    deleteSubscriptionPolicy: compose(requireCsrfMutatingApi, apiMetadataService.deleteSubscriptionPolicy),
 };

--- a/src/openapi/handlers/subscriptionPolicies.js
+++ b/src/openapi/handlers/subscriptionPolicies.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Subscription Policies
+ */
+
+const apiMetadataService = require('../../services/apiMetadataService');
+
+module.exports = {
+    addSubscriptionPolicies: apiMetadataService.addSubscriptionPolicies,
+    putSubscriptionPolicies: apiMetadataService.putSubscriptionPolicies,
+    getSubscriptionPolicy: apiMetadataService.getSubscriptionPolicy,
+    deleteSubscriptionPolicy: apiMetadataService.deleteSubscriptionPolicy,
+};

--- a/src/openapi/handlers/subscriptionPolicies.js
+++ b/src/openapi/handlers/subscriptionPolicies.js
@@ -21,12 +21,12 @@
  * Tag: Subscription Policies
  */
 const apiMetadataService = require('../../services/apiMetadataService');
-const requireCsrfMutatingApi = require('../../middlewares/csrfProtection')
+const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection')
 const { compose } = require('./_compose');
 
 module.exports = {
-    addSubscriptionPolicies: compose(requireCsrfMutatingApi, apiMetadataService.addSubscriptionPolicies),
-    putSubscriptionPolicies: compose(requireCsrfMutatingApi, apiMetadataService.putSubscriptionPolicies),
+    addSubscriptionPolicies: compose(requireCsrfForMutatingApi, apiMetadataService.addSubscriptionPolicies),
+    putSubscriptionPolicies: compose(requireCsrfForMutatingApi, apiMetadataService.putSubscriptionPolicies),
     getSubscriptionPolicy: apiMetadataService.getSubscriptionPolicy,
-    deleteSubscriptionPolicy: compose(requireCsrfMutatingApi, apiMetadataService.deleteSubscriptionPolicy),
+    deleteSubscriptionPolicy: compose(requireCsrfForMutatingApi, apiMetadataService.deleteSubscriptionPolicy),
 };

--- a/src/openapi/handlers/subscriptionPolicies.js
+++ b/src/openapi/handlers/subscriptionPolicies.js
@@ -1,10 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Subscription Policies
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Subscription Policies
+ */
 const apiMetadataService = require('../../services/apiMetadataService');
 
 module.exports = {

--- a/src/openapi/handlers/subscriptions.js
+++ b/src/openapi/handlers/subscriptions.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Subscriptions
+ *
+ * `unsubscribeAPI` is the DELETE /organizations/{orgId}/subscriptions
+ * (no path subscriptionId — bulk/unscoped delete). The single-id DELETE
+ * is `deleteSubscription`.
+ */
+
+const adminService = require('../../services/adminService');
+
+module.exports = {
+    createSubscription: adminService.createSubscription,
+    updateSubscription: adminService.updateSubscription,
+    getSubscription: adminService.getSubscription,
+    getAllSubscriptions: adminService.getAllSubscriptions,
+    deleteSubscription: adminService.deleteSubscription,
+    unsubscribeAPI: adminService.unsubscribeAPI,
+};

--- a/src/openapi/handlers/subscriptions.js
+++ b/src/openapi/handlers/subscriptions.js
@@ -1,14 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Subscriptions
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * `unsubscribeAPI` is the DELETE /organizations/{orgId}/subscriptions
- * (no path subscriptionId — bulk/unscoped delete). The single-id DELETE
- * is `deleteSubscription`.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Subscriptions
+ */
 const adminService = require('../../services/adminService');
 
 module.exports = {

--- a/src/openapi/handlers/usage.js
+++ b/src/openapi/handlers/usage.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Usage
+ */
+
+const usageController = require('../../controllers/usageController');
+const { ensureBillingAuth } = require('../../middlewares/billingAuth');
+const { compose } = require('./_compose');
+
+module.exports = {
+    getSubscriptionUsage: compose(ensureBillingAuth, usageController.getSubscriptionUsage),
+};

--- a/src/openapi/handlers/usage.js
+++ b/src/openapi/handlers/usage.js
@@ -1,10 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Usage
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Usage
+ */
 const usageController = require('../../controllers/usageController');
 const { ensureBillingAuth } = require('../../middlewares/billingAuth');
 const { compose } = require('./_compose');

--- a/src/openapi/handlers/utilities.js
+++ b/src/openapi/handlers/utilities.js
@@ -1,12 +1,24 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/*
  * Tag: Utilities
- *
- * The legacy router defines /temp-arazzo-file inline. The handler is
- * extracted here verbatim so the new path can route to it without depending
- * on devportalRoute.js. CSRF guard mirrors the legacy route.
  */
 
 const path = require('path');

--- a/src/openapi/handlers/utilities.js
+++ b/src/openapi/handlers/utilities.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Utilities
+ *
+ * The legacy router defines /temp-arazzo-file inline. The handler is
+ * extracted here verbatim so the new path can route to it without depending
+ * on devportalRoute.js. CSRF guard mirrors the legacy route.
+ */
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs').promises;
+const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection');
+const { compose } = require('./_compose');
+
+async function createTempArazzoFileImpl(req, res, next) {
+    const { content, filename } = req.body || {};
+    if (!content || typeof content !== 'string') {
+        return res.status(400).json({ error: 'content is required' });
+    }
+    const safeName = (filename || 'workflow.arazzo.yaml')
+        .replace(/[^a-zA-Z0-9._-]/g, '-')
+        .replace(/\.\.+/g, '.')
+        .substring(0, 120);
+    try {
+        const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'arazzo-'));
+        const tmpPath = path.join(tmpDir, safeName);
+        await fs.writeFile(tmpPath, content, 'utf8');
+        res.json({ path: tmpPath });
+    } catch (err) {
+        next(err);
+    }
+}
+
+module.exports = {
+    createTempArazzoFile: compose(requireCsrfForMutatingApi, createTempArazzoFileImpl),
+};

--- a/src/openapi/handlers/utilities.js
+++ b/src/openapi/handlers/utilities.js
@@ -27,6 +27,15 @@ const fs = require('fs').promises;
 const { requireCsrfForMutatingApi } = require('../../middlewares/csrfProtection');
 const { compose } = require('./_compose');
 
+function isSafeFileName(fileName) {
+    return Boolean(
+        fileName &&
+        fileName !== '.' &&
+        fileName !== '..' &&
+        path.basename(fileName) === fileName
+    );
+}
+
 async function createTempArazzoFileImpl(req, res, next) {
     const { content, filename } = req.body || {};
     if (!content || typeof content !== 'string') {
@@ -36,6 +45,9 @@ async function createTempArazzoFileImpl(req, res, next) {
         .replace(/[^a-zA-Z0-9._-]/g, '-')
         .replace(/\.\.+/g, '.')
         .substring(0, 120);
+    if (!isSafeFileName(safeName)) {
+        return res.status(400).json({ error: 'filename is invalid' });
+    }
     try {
         const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'arazzo-'));
         const tmpPath = path.join(tmpDir, safeName);

--- a/src/openapi/handlers/views.js
+++ b/src/openapi/handlers/views.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * Tag: Views
+ */
+
+const apiMetadataService = require('../../services/apiMetadataService');
+
+module.exports = {
+    addView: apiMetadataService.addView,
+    getView: apiMetadataService.getView,
+    getAllViews: apiMetadataService.getAllViews,
+    updateView: apiMetadataService.updateView,
+    deleteView: apiMetadataService.deleteView,
+};

--- a/src/openapi/handlers/views.js
+++ b/src/openapi/handlers/views.js
@@ -1,10 +1,25 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
- * Licensed under the Apache License, Version 2.0.
  *
- * Tag: Views
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
+/*
+ * Tag: Views
+ */
 const apiMetadataService = require('../../services/apiMetadataService');
 
 module.exports = {

--- a/src/openapi/middleware/auth.js
+++ b/src/openapi/middleware/auth.js
@@ -1,9 +1,20 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * See the License file for the specific language governing permissions and
- * limitations under the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 
 /*
@@ -12,16 +23,10 @@
  *   authResolver  →  OpenAPI validator (calls OAuth2Security / apiKeyAuth)  →  handler
  *
  * `authResolver` runs once per /devportal request and resolves credentials in the
- * same order as the legacy `enforceSecuirty` (local → bearer → basic → api key →
- * mTLS). It populates `req.auth` with `{ mode, scopes, preauthorized, userId }`
- * but does NOT enforce scopes — that is the job of `OAuth2Security`, which the
- * validator invokes with the operation-declared scope list.
+ * order local → bearer → basic → api key → mTLS). It populates `req.auth` with 
+ * `{ mode, scopes, preauthorized, userId } but does NOT enforce scopes — that is the job of `OAuth2Security`, 
+ * which the validator invokes with the operation-declared scope list.
  *
- * The JWT/JWKS/cert/basic/api-key/mTLS helpers below are intentionally forked
- * from src/middlewares/ensureAuthenticated.js so the legacy path can stay
- * untouched while both code paths run side-by-side under the
- * `advanced.useOpenApiValidator` toggle. Once the legacy path is retired this
- * file becomes the single source of truth.
  */
 
 const axios = require('axios');
@@ -285,7 +290,8 @@ async function OAuth2Security(req /* , requiredScopes, schema */) {
  * mirror legacy behaviour where API key endpoints also accepted basic/mTLS).
  */
 /*
- * TODO: once the API key support introduces with scope support, change the method to check for scopes as well, and rename it to ApiKeySecurity for clarity.
+ * TODO: once the API key support introduces with scope support, change the method 
+ * to check for scopes as well, and rename it to ApiKeySecurity for clarity.
  */
 async function apiKeyAuth(req /* , scopes, schema */) {
     if (req.auth?.mode === 'apikey' || req.auth?.preauthorized) return true;

--- a/src/openapi/middleware/auth.js
+++ b/src/openapi/middleware/auth.js
@@ -40,6 +40,16 @@ const adminDao = require('../../dao/admin');
 const IdentityProviderDTO = require('../../dto/identityProvider');
 const logger = require('../../config/logger');
 
+const DEFAULT_TOKEN_REFRESH_TIMEOUT_MS = 10000;
+
+function resolveTokenRefreshTimeoutMs() {
+    const timeout = Number(config.identityProvider?.tokenRefreshTimeoutMs);
+    if (Number.isFinite(timeout) && timeout > 0) {
+        return timeout;
+    }
+    return DEFAULT_TOKEN_REFRESH_TIMEOUT_MS;
+}
+
 function accessTokenPresent(req) {
     if (req.user && req.user[constants.ACCESS_TOKEN]) {
         return req.user[constants.ACCESS_TOKEN];
@@ -59,6 +69,7 @@ async function refreshAccessToken(refreshToken) {
     });
     const response = await axios.post(config.identityProvider.tokenURL, data, {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        timeout: resolveTokenRefreshTimeoutMs(),
     });
     return response.data;
 }

--- a/src/openapi/middleware/auth.js
+++ b/src/openapi/middleware/auth.js
@@ -284,6 +284,9 @@ async function OAuth2Security(req /* , requiredScopes, schema */) {
  * authenticated it via API key (or any preauthorized non-OAuth mode, to
  * mirror legacy behaviour where API key endpoints also accepted basic/mTLS).
  */
+/*
+ * TODO: once the API key support introduces with scope support, change the method to check for scopes as well, and rename it to ApiKeySecurity for clarity.
+ */
 async function apiKeyAuth(req /* , scopes, schema */) {
     if (req.auth?.mode === 'apikey' || req.auth?.preauthorized) return true;
     const err = new Error('Authentication required');

--- a/src/openapi/middleware/auth.js
+++ b/src/openapi/middleware/auth.js
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * See the License file for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Auth pipeline for the spec-driven /devportal router.
+ *
+ *   authResolver  →  OpenAPI validator (calls OAuth2Security / apiKeyAuth)  →  handler
+ *
+ * `authResolver` runs once per /devportal request and resolves credentials in the
+ * same order as the legacy `enforceSecuirty` (local → bearer → basic → api key →
+ * mTLS). It populates `req.auth` with `{ mode, scopes, preauthorized, userId }`
+ * but does NOT enforce scopes — that is the job of `OAuth2Security`, which the
+ * validator invokes with the operation-declared scope list.
+ *
+ * The JWT/JWKS/cert/basic/api-key/mTLS helpers below are intentionally forked
+ * from src/middlewares/ensureAuthenticated.js so the legacy path can stay
+ * untouched while both code paths run side-by-side under the
+ * `advanced.useOpenApiValidator` toggle. Once the legacy path is retired this
+ * file becomes the single source of truth.
+ */
+
+const axios = require('axios');
+const qs = require('qs');
+const jwt = require('jsonwebtoken');
+const { jwtVerify, createRemoteJWKSet, importX509 } = require('jose');
+
+const { config, secrets } = require('../../config/configLoader');
+const constants = require('../../utils/constants');
+const adminDao = require('../../dao/admin');
+const IdentityProviderDTO = require('../../dto/identityProvider');
+const logger = require('../../config/logger');
+
+function accessTokenPresent(req) {
+    if (req.user && req.user[constants.ACCESS_TOKEN]) {
+        return req.user[constants.ACCESS_TOKEN];
+    }
+    const auth = req.headers.authorization;
+    if (auth && auth.toLowerCase().startsWith('bearer ')) {
+        return auth.split(' ')[1];
+    }
+    return null;
+}
+
+async function refreshAccessToken(refreshToken) {
+    const data = qs.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: config.identityProvider.clientId,
+    });
+    const response = await axios.post(config.identityProvider.tokenURL, data, {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+    return response.data;
+}
+
+async function verifyJwksWithRefresh(token, jwksURL, req) {
+    try {
+        const jwks = await createRemoteJWKSet(new URL(jwksURL));
+        const { payload } = await jwtVerify(token, jwks);
+        return { valid: true, scopes: payload.scope || '' };
+    } catch (err) {
+        if (err.code === 'ERR_JWT_EXPIRED' && req.user && req.user.refreshToken) {
+            try {
+                logger.info('Access token expired during /devportal request, refreshing');
+                const refreshed = await refreshAccessToken(req.user.refreshToken);
+                req.user[constants.ACCESS_TOKEN] = refreshed.access_token;
+                req.user[constants.REFRESH_TOKEN] = refreshed.refresh_token;
+                return { valid: true, scopes: refreshed.scope || '', refreshed };
+            } catch (refreshErr) {
+                logger.error('Refresh token flow failed', {
+                    error: refreshErr.message,
+                    stack: refreshErr.stack,
+                    operation: 'refreshAccessToken',
+                });
+                return { valid: false, scopes: '' };
+            }
+        }
+        logger.error('Bearer token validation failed', {
+            error: err.message,
+            operation: 'verifyJwksWithRefresh',
+        });
+        return { valid: false, scopes: '' };
+    }
+}
+
+async function verifyWithCertificate(token, pemCertificate) {
+    try {
+        const publicKey = await importX509(pemCertificate, 'RS256');
+        const { payload } = await jwtVerify(token, publicKey);
+        return { valid: true, scopes: payload.scope || '' };
+    } catch (err) {
+        logger.error('Bearer token cert validation failed', {
+            error: err.message,
+            operation: 'verifyWithCertificate',
+        });
+        return { valid: false, scopes: '' };
+    }
+}
+
+async function resolveOrgIdp(req) {
+    let orgId;
+    if (req.params && req.params.orgId) {
+        orgId = req.params.orgId;
+    } else if (req.params && req.params.orgName) {
+        orgId = await adminDao.getOrgId(req.params.orgName);
+    }
+    if (!orgId) return config.identityProvider || {};
+    const rows = await adminDao.getIdentityProvider(orgId);
+    if (rows && rows.length > 0) {
+        return new IdentityProviderDTO(rows[0].dataValues);
+    }
+    return config.identityProvider || {};
+}
+
+async function verifyBearerToken(token, req) {
+    const idp = await resolveOrgIdp(req);
+    if (!idp || !idp.clientId) {
+        // No IdP configured — accept bearer presence (legacy parity), no scopes.
+        return { valid: true, scopes: '' };
+    }
+    if (idp.certificate) {
+        return verifyWithCertificate(token, idp.certificate);
+    }
+    if (idp.jwksURL) {
+        return verifyJwksWithRefresh(token, idp.jwksURL, req);
+    }
+    return { valid: false, scopes: '' };
+}
+
+async function validateBasicAuth(basicHeader) {
+    const decoded = Buffer.from(basicHeader, 'base64').toString('utf-8');
+    const [username, password] = decoded.split(':');
+    const users = config.defaultAuth?.users || [];
+    return users.some(u => u.username === username && u.password === password);
+}
+
+function checkOrgMembership(req) {
+    if (!req.user) return true;
+    const tokenOrg = req.user[constants.ROLES.ORGANIZATION_CLAIM];
+    const targetOrg = req.user[constants.ORG_IDENTIFIER];
+    if (!targetOrg || tokenOrg === targetOrg) return true;
+    const authorizedOrgs = req.user.authorizedOrgs;
+    return Array.isArray(authorizedOrgs) && authorizedOrgs.includes(targetOrg);
+}
+
+/**
+ * Pre-validator middleware that establishes `req.auth`. Runs once per
+ * /devportal request before the OpenAPI validator security check.
+ */
+async function authResolver(req, res, next) {
+    try {
+        // 1. Local config-auth users (no IdP configured) — pre-authorized
+        if (req.isAuthenticated && req.isAuthenticated() &&
+            req.user?.isLocalAuth && !config.identityProvider?.clientId) {
+            req.auth = {
+                mode: 'local',
+                preauthorized: true,
+                scopes: [],
+                userId: req.user[constants.USER_ID],
+            };
+            return next();
+        }
+
+        // 2. Bearer token (session-attached or Authorization header)
+        const token = accessTokenPresent(req);
+        if (token) {
+            if (!checkOrgMembership(req)) {
+                const err = new Error('Authentication required');
+                err.status = 401;
+                return next(err);
+            }
+            const { valid, scopes } = await verifyBearerToken(token, req);
+            if (!valid) {
+                const err = new Error('Authentication required');
+                err.status = 401;
+                return next(err);
+            }
+            const decoded = jwt.decode(req.user?.[constants.ACCESS_TOKEN] || token) || {};
+            req[constants.USER_ID] = decoded[constants.USER_ID];
+            req.auth = {
+                mode: 'oauth2',
+                scopes: String(scopes || '').split(' ').filter(Boolean),
+                userId: decoded[constants.USER_ID],
+            };
+            return next();
+        }
+
+        // 3. Basic auth (no IdP configured path)
+        const authHeader = req.headers.authorization;
+        if (!config.identityProvider?.clientId &&
+            authHeader && authHeader.toLowerCase().startsWith('basic ')) {
+            const basicHeader = authHeader.split(' ')[1];
+            const ok = await validateBasicAuth(basicHeader);
+            if (ok) {
+                req.auth = { mode: 'basic', preauthorized: true, scopes: [] };
+                return next();
+            }
+            const err = new Error('Authentication required');
+            err.status = 401;
+            return next(err);
+        }
+
+        // 4. API key
+        if (config.advanced?.apiKey?.enabled) {
+            const keyType = config.advanced.apiKey.keyType;
+            if (keyType && secrets.apiKeySecret) {
+                const apiKey = req.headers[keyType.toLowerCase()];
+                if (apiKey && apiKey === secrets.apiKeySecret) {
+                    if (req.headers.organization && req.params && !req.params.orgId) {
+                        req.params.orgId = req.headers.organization;
+                    }
+                    req.auth = { mode: 'apikey', preauthorized: true, scopes: [] };
+                    return next();
+                }
+            }
+        }
+
+        // 5. mTLS
+        if (typeof req.connection?.getPeerCertificate === 'function') {
+            const cert = req.connection.getPeerCertificate(true);
+            if (cert && Object.keys(cert).length > 0 && req.client?.authorized) {
+                const now = new Date();
+                if (new Date(cert.valid_from) <= now && new Date(cert.valid_to) >= now) {
+                    req.auth = { mode: 'mtls', preauthorized: true, scopes: [] };
+                    return next();
+                }
+            }
+        }
+
+        // 6. No usable credential
+        const err = new Error('Authentication required');
+        err.status = 401;
+        return next(err);
+    } catch (err) {
+        logger.error('authResolver failed', {
+            error: err.message,
+            stack: err.stack,
+            operation: 'authResolver',
+        });
+        return res.status(500).json({ error: 'Internal Server Error' });
+    }
+}
+
+/**
+ * OAuth2 security handler invoked by express-openapi-validator with the
+ * scope list declared on the operation. Implements any-of semantics over
+ * a single security requirement object, matching the OpenAPI spec.
+ *
+ * Honors `config.advanced.disableScopeValidation` — when true, scope
+ * intersection is skipped (request only needs to be authenticated).
+ */
+async function OAuth2Security(req /* , requiredScopes, schema */) {
+    const requiredScopes = arguments[1] || [];
+    if (!req.auth) {
+        const err = new Error('Authentication required');
+        err.status = 401;
+        throw err;
+    }
+    if (req.auth.preauthorized) return true;
+    if (config.advanced?.disableScopeValidation) return true;
+    if (req.auth.mode !== 'oauth2') {
+        const err = new Error('Authentication required');
+        err.status = 401;
+        throw err;
+    }
+    if (!requiredScopes || requiredScopes.length === 0) return true;
+    const tokenScopes = req.auth.scopes || [];
+    const ok = requiredScopes.some(s => tokenScopes.includes(s));
+    if (!ok) {
+        const err = new Error('Forbidden');
+        err.status = 403;
+        throw err;
+    }
+    return true;
+}
+
+/**
+ * API key security handler. Accepts the request if authResolver already
+ * authenticated it via API key (or any preauthorized non-OAuth mode, to
+ * mirror legacy behaviour where API key endpoints also accepted basic/mTLS).
+ */
+async function apiKeyAuth(req /* , scopes, schema */) {
+    if (req.auth?.mode === 'apikey' || req.auth?.preauthorized) return true;
+    const err = new Error('Authentication required');
+    err.status = 401;
+    throw err;
+}
+
+module.exports = {
+    authResolver,
+    OAuth2Security,
+    apiKeyAuth,
+};


### PR DESCRIPTION
## Purpose

- Currently, **Developer** portal backend does not have a formal API contract & legacy `src/routes/devportalRoutes.js` registers routes by hand and delegates request validation to business layer.
- This PR introduces a **fine-grained OpenAPI 3.0** specification for Devportal at `docs/devportal-openapi-spec-v1.yaml` and a spec-driven router that uses it as the source of truth for routing, validation, and authorization. Existing services and controllers are reused unchanged.
- Related to : https://github.com/wso2-enterprise/apim-product-management/issues/375

## Approach

- Introduces`OpenApiValidator` for the schema validation which offloads the overhead of validating params, requests, responses inside the business logic layer. 

 ```mermaid
flowchart LR
A[Request] --> B[AuthResolver]
B --> C[OpenApiValidator<br/>schema + security]
C --> D[operation handler<br/> = exisitng service fn]
```
- authResolver `src/openapi/middleware/auth.js` — runs once per `/devportal` request, identifies the credential mode (local / OAuth bearer / basic / api-key / mTLS — same five modes as the legacy enforceSecuirty),
  validates the credential, and populates `req.auth = { mode, scopes, preauthorized }`. JWT verification still resolves the per-org IdP.
- OpenApiValidator is configured with:
    - **validateRequests: true** — every path/query/body validated against the spec, including additionalProperties: false.
    - **validateSecurity** — the spec's OAuth2Security and apiKeyAuth handlers are wired to functions in auth.js. Scope check is any-of (token must hold at least one of the operation's declared scopes), honors
  `advanced.disableScopeValidation`, and is skipped for non-OAuth credential modes (matching legacy behaviour).
    - **validateResponses** — controlled by advanced.openApiValidator.validateResponses (false / true / 'log-only').
    - **operationHandlers** — uses a custom resolver that maps the operation's first tag to a handler file, then looks up the function by operationId.
  - Handlers are thin shims: each file in `src/openapi/handlers/<tag>.js` exports functions named after the spec's **operationIds**, delegating to existing `services/*` and `controllers/*`. Routes that need additional
  middleware (CSRF, billing-auth, request-origin verification) compose them via a small compose() helper that runs middleware in order before the handler.
  - Routing convention — first tag of an operation is camel-cased to a filename. Examples:
  
```
  Organizations         → organizations.js
  Identity Providers    → identityProviders.js
  Platform API Keys     → platformApiKeys.js
  API Flows             → apiFlows.js
```

## Instructions

- This new routing revamp has been done on top of `config.yaml` change & to enable the new flow, add below config to the `config.yaml`

```
advanced:
  . . .
  useOpenApiValidator: true
  openApiValidator:
       validateResponses: log-only      # logs drift via warn-level logs, doesn't break clients


Or via env (case-insensitive, __ for literal underscore):

  DP_ADVANCED_USEOPENAPIVALIDATOR=true
  DP_ADVANCED_OPENAPIVALIDATOR_VALIDATERESPONSES=log-only
```

## Samples

```shell
  # Required fields enforced — `groupsClaimName` missing → 400
  curl -s -u admin:admin -H 'Content-Type: application/json' \
    -d '{"orgName":"Acme","orgHandle":"acme","roleClaimName":"roles", \
         "organizationClaimName":"organizationIdentifier", \
         "organizationIdentifier":"ACME","adminRole":"admin", \
         "subscriberRole":"sub","superAdminRole":"super"}' \
    http://localhost:3000/devportal/organizations
  # → 400 {"code":400,"message":"request.body should have required property 'groupsClaimName'", ...}
```
