### PR TITLE
Add YAML support for subscription plans

### DIFF
--- a/docs/devportal-openapi-spec-v1.yaml
+++ b/docs/devportal-openapi-spec-v1.yaml
@@ -3264,7 +3264,9 @@ components:
       description: >-
         Subscription policy payload. Send a single object for single create/upsert, or a non-empty array
         for bulk create/upsert. The service currently processes policies with `type` set to
-        `requestcount` or `eventcount`.
+        `requestcount` or `eventcount`. Alternatively, upload a YAML file in the `subscriptionPolicy`
+        multipart field; use `kind: SubscriptionPolicy` for a single policy or `kind: SubscriptionPolicyList`
+        with an `items` array for bulk operations.
       content:
         application/json:
           schema:
@@ -3274,6 +3276,25 @@ components:
                 minItems: 1
                 items:
                   $ref: "#/components/schemas/SubscriptionPolicyRequest"
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              subscriptionPolicy:
+                type: string
+                format: binary
+                description: >-
+                  Subscription policy YAML file. Use `kind: SubscriptionPolicy` for a single policy
+                  or `kind: SubscriptionPolicyList` (with an `items` array) for bulk operations.
+          examples:
+            singlePolicy:
+              summary: Single subscription policy YAML upload
+              value:
+                subscriptionPolicy: plan.yaml
+            policyList:
+              summary: Bulk subscription policy YAML upload
+              value:
+                subscriptionPolicy: plans.yaml
     LabelsBody:
       required: true
       description: Label array to create or upsert.

--- a/src/dao/apiMetadata.js
+++ b/src/dao/apiMetadata.js
@@ -485,6 +485,7 @@ const buildSubscriptionPolicyRow = (orgID, policy) => {
     BILLING_PLAN: policy.billingPlan,
     DESCRIPTION: policy.description,
     REQUEST_COUNT: requestCount,
+    REF_ID: policy.refId ?? null,
 
     PRICING_MODEL: toUpper(policy.pricingModel) ?? null,
     CURRENCY: policy.currency ?? null,

--- a/src/dao/apiMetadata.js
+++ b/src/dao/apiMetadata.js
@@ -593,6 +593,9 @@ const updateSubscriptionPolicy = async (orgID, policyID, policy, t) => {
     // Don’t update primary keys
     delete row.ORG_ID;
     delete row.POLICY_ID;
+    if (!Object.prototype.hasOwnProperty.call(policy, 'refId')) {
+      delete row.REF_ID;
+    }
 
     const [_, updatedRows] = await SubscriptionPolicy.update(row, {
       where: { POLICY_ID: policyID, ORG_ID: orgID },

--- a/src/dto/subscriptionPolicy.js
+++ b/src/dto/subscriptionPolicy.js
@@ -24,6 +24,7 @@ class SubscriptionPolicy {
         this.billingPlan = subscriptionPolicy.BILLING_PLAN;
         this.description = subscriptionPolicy.DESCRIPTION;
         this.requestCount = subscriptionPolicy.REQUEST_COUNT;
+        this.refId = subscriptionPolicy.REF_ID;
         this.orgID = subscriptionPolicy.ORG_ID;
         
         // Pricing fields

--- a/src/routes/devportalRoute.js
+++ b/src/routes/devportalRoute.js
@@ -88,9 +88,9 @@ router.put(
     apiMetadataService.updateAPIMetadata);
 router.delete('/organizations/:orgId/apis/:apiId', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.deleteAPIMetadata);
 
-router.post('/organizations/:orgId/subscription-policies', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.addSubscriptionPolicies);
+router.post('/organizations/:orgId/subscription-policies', enforceSecuirty(constants.SCOPES.DEVELOPER), multipartHandler.fields([{ name: 'subscriptionPolicy', maxCount: 1 }]), apiMetadataService.addSubscriptionPolicies);
 router.get('/organizations/:orgId/subscription-policies/:policyID', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.getSubscriptionPolicy);
-router.put('/organizations/:orgId/subscription-policies', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.putSubscriptionPolicies);
+router.put('/organizations/:orgId/subscription-policies', enforceSecuirty(constants.SCOPES.DEVELOPER), multipartHandler.fields([{ name: 'subscriptionPolicy', maxCount: 1 }]), apiMetadataService.putSubscriptionPolicies);
 router.delete('/organizations/:orgId/subscription-policies/:policyName', enforceSecuirty(constants.SCOPES.DEVELOPER), apiMetadataService.deleteSubscriptionPolicy);
 
 const apiZip = multer({ dest: '/tmp' });

--- a/src/services/apiMetadataService.js
+++ b/src/services/apiMetadataService.js
@@ -1057,6 +1057,14 @@ const deleteAPIFile = async (req, res) => {
 };
 
 const addSubscriptionPolicies = async (req, res) => {
+    if (req.files?.subscriptionPolicy?.[0]) {
+        try {
+            const policies = parseSubscriptionPoliciesFromYamlFile(req.files.subscriptionPolicy[0].buffer);
+            req.body = policies.length === 1 ? policies[0] : policies;
+        } catch (error) {
+            return util.handleError(res, error);
+        }
+    }
     if (Array.isArray(req.body)) {
         await createSubscriptionPolicies(req, res);
     } else {
@@ -1065,6 +1073,14 @@ const addSubscriptionPolicies = async (req, res) => {
 }
 
 const putSubscriptionPolicies = async (req, res) => {
+    if (req.files?.subscriptionPolicy?.[0]) {
+        try {
+            const policies = parseSubscriptionPoliciesFromYamlFile(req.files.subscriptionPolicy[0].buffer);
+            req.body = policies.length === 1 ? policies[0] : policies;
+        } catch (error) {
+            return util.handleError(res, error);
+        }
+    }
     if (Array.isArray(req.body)) {
         await updateSubscriptionPolicies(req, res);
     } else {
@@ -1867,6 +1883,55 @@ function parseApiMetadataFromYamlRequest(req) {
     }
 
     return parseApiMetadataFromYamlFile(apiFile.originalname, apiFile.buffer);
+}
+
+function mapYamlToSubscriptionPolicy(item) {
+    const { metadata = {}, spec = {} } = item;
+    return {
+        policyName: metadata.name,
+        displayName: spec.displayName,
+        billingPlan: spec.billingPlan || 'FREE',
+        description: spec.description,
+        refId: spec.refId,
+        type: spec.type,
+        requestCount: spec.requestCount,
+        eventCount: spec.eventCount,
+        pricingModel: spec.pricingModel,
+        currency: spec.currency,
+        billingPeriod: spec.billingPeriod,
+        flatAmount: spec.flatAmount,
+        unitAmount: spec.unitAmount,
+        externalProductId: spec.externalProductId,
+        externalPriceId: spec.externalPriceId,
+        pricingTiers: spec.pricingTiers,
+    };
+}
+
+function parseSubscriptionPoliciesFromYamlFile(fileBuffer) {
+    let parsed;
+    try {
+        parsed = yaml.load(fileBuffer.toString(constants.CHARSET_UTF8));
+    } catch (e) {
+        throw new Sequelize.ValidationError(`Invalid subscription policy YAML file: ${e.message}`);
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+        throw new Sequelize.ValidationError('Subscription policy YAML file is empty or invalid');
+    }
+
+    const kind = parsed.kind;
+    if (kind === 'SubscriptionPolicy') {
+        return [mapYamlToSubscriptionPolicy(parsed)];
+    } else if (kind === 'SubscriptionPolicyList') {
+        if (!Array.isArray(parsed.items) || parsed.items.length === 0) {
+            throw new Sequelize.ValidationError("SubscriptionPolicyList must have a non-empty 'items' array");
+        }
+        return parsed.items.map(mapYamlToSubscriptionPolicy);
+    } else {
+        throw new Sequelize.ValidationError(
+            `Unknown subscription policy YAML kind '${kind}'. Expected 'SubscriptionPolicy' or 'SubscriptionPolicyList'`
+        );
+    }
 }
 
 function prepareApiDefinitionForStorage(fileName, fileBuffer) {


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2-enterprise/apim-saas/issues/2600
This change introduces YAML support for subscription-policy endpoints. It also fixes a pre-existing gap where REF_ID was stored in the database model but was never written on create/update and never returned in responses.

## Approach
- The POST and PUT /organizations/:orgId/subscription-policies routes now accept multipart form data via the existing multipartHandler middleware. A subscriptionPolicy file field carries the YAML.
- This accepts both
   - SubscriptionPolicy yaml
   - SubscriptionPolicyList yaml
- JSON body requests are unaffected — the file check short-circuits before any existing logic runs.


## Samples

Follows the same `apiVersion` / `kind` / `metadata` / `spec` convention as `api.yaml`:

```yaml
# Single plan
apiVersion: devportal.api-platform.wso2.com/v1
kind: SubscriptionPolicy
metadata:
  name: Gold
spec:
  displayName: Gold Plan
  billingPlan: FREE
  type: requestcount
  requestCount: 5000
  description: Allows 5000 requests per minute
  refId: cp-plan-gold           # optional external reference
```

```yaml
# Multiple plans in one file
apiVersion: devportal.api-platform.wso2.com/v1
kind: SubscriptionPolicyList
items:
  - metadata:
      name: Gold
    spec:
      displayName: Gold Plan
      billingPlan: FREE
      type: requestcount
      requestCount: 5000
  - metadata:
      name: Unlimited
    spec:
      displayName: Unlimited
      billingPlan: FREE
      type: requestcount
      requestCount: -1
```

**Upload examples:**

```bash
# Create a single plan from YAML
curl -X POST https://<host>/devportal/organizations/{orgId}/subscription-policies \
  -H "Authorization: Bearer <token>" \
  -F "subscriptionPolicy=@gold.yaml"

# Upsert multiple plans from a list file
curl -X PUT https://<host>/devportal/organizations/{orgId}/subscription-policies \
  -F "subscriptionPolicy=@plans.yaml"
```

