### PR TITLE
Add YAML support for org and idp creation/updating

### DIFF
--- a/docs/devportal-openapi-spec-v1.yaml
+++ b/docs/devportal-openapi-spec-v1.yaml
@@ -3248,6 +3248,8 @@ components:
         multipart/form-data:
           schema:
             type: object
+            required:
+              - organization
             properties:
               organization:
                 type: string
@@ -3271,6 +3273,8 @@ components:
         multipart/form-data:
           schema:
             type: object
+            required:
+              - organization
             properties:
               organization:
                 type: string
@@ -3283,10 +3287,29 @@ components:
                 organization: org.yaml
     IdentityProviderBody:
       required: true
+      description: >-
+        Identity provider payload. Send JSON or an identity provider YAML file in the
+        `identityProvider` multipart field. When YAML is used, the service reads `metadata.name`
+        as the provider name and all other fields from `spec`.
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/IdentityProviderRequest"
+        multipart/form-data:
+          schema:
+            type: object
+            required:
+              - identityProvider
+            properties:
+              identityProvider:
+                type: string
+                format: binary
+                description: "Identity provider YAML file (kind: IdentityProvider)."
+          examples:
+            yamlFile:
+              summary: Identity provider YAML upload
+              value:
+                identityProvider: idp.yaml
     ProviderBody:
       required: true
       content:

--- a/docs/devportal-openapi-spec-v1.yaml
+++ b/docs/devportal-openapi-spec-v1.yaml
@@ -3224,6 +3224,10 @@ components:
             $ref: "#/components/schemas/GenericObject"
     OrganizationCreateBody:
       required: true
+      description: >-
+        Organization creation payload. Send JSON or an organization YAML file in the `organization`
+        multipart field. When YAML is used, the service reads `metadata.name` as `orgHandle` and
+        `spec.displayName` as `orgName`; all other fields are read from `spec`.
       content:
         application/json:
           schema:
@@ -3241,12 +3245,42 @@ components:
             adminRole: admin
             subscriberRole: subscriber
             superAdminRole: superAdmin
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              organization:
+                type: string
+                format: binary
+                description: "Organization YAML file (kind: Organization)."
+          examples:
+            yamlFile:
+              summary: Organization YAML upload
+              value:
+                organization: org.yaml
     OrganizationUpdateBody:
       required: true
+      description: >-
+        Organization update payload. Send JSON or an organization YAML file in the `organization`
+        multipart field. When YAML is used, the service reads `metadata.name` as `orgHandle` and
+        `spec.displayName` as `orgName`; all other fields are read from `spec`.
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/OrganizationUpdateRequest"
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              organization:
+                type: string
+                format: binary
+                description: "Organization YAML file (kind: Organization)."
+          examples:
+            yamlFile:
+              summary: Organization YAML upload
+              value:
+                organization: org.yaml
     IdentityProviderBody:
       required: true
       content:

--- a/src/dao/admin.js
+++ b/src/dao/admin.js
@@ -121,7 +121,7 @@ const getOrganizations = async () => {
     }
 };
 
-const updateOrganization = async (orgData) => {
+const updateOrganization = async (orgData, t) => {
     let devPortalID = "";
     if (orgData.orgHandle) {
         devPortalID = orgData.orgHandle
@@ -145,7 +145,8 @@ const updateOrganization = async (orgData) => {
             },
             {
                 where: { ORG_ID: orgData.orgId },
-                returning: true
+                returning: true,
+                transaction: t,
             }
         );
         if (updatedRowsCount < 1) {
@@ -177,7 +178,7 @@ const deleteOrganization = async (orgId) => {
     }
 }
 
-const createIdentityProvider = async (orgId, idpData) => {
+const createIdentityProvider = async (orgId, idpData, t) => {
     try {
         const idpResponse = await IdentityProvider.create({
             ORG_ID: orgId,
@@ -194,7 +195,7 @@ const createIdentityProvider = async (orgId, idpData) => {
             ...(idpData.scope && { SCOPE: idpData.scope }),
             ...(idpData.jwksURL && { JWKS_URL: idpData.jwksURL }),
             ...(idpData.certificate && { CERTIFICATE: idpData.certificate })
-        });
+        }, { transaction: t });
         return idpResponse;
     } catch (error) {
         if (error instanceof Sequelize.UniqueConstraintError) {
@@ -204,7 +205,7 @@ const createIdentityProvider = async (orgId, idpData) => {
     }
 }
 
-const updateIdentityProvider = async (orgID, idpData) => {
+const updateIdentityProvider = async (orgID, idpData, t) => {
     try {
         const [updatedRowsCount, idpContent] = await IdentityProvider.update(
             {
@@ -224,10 +225,9 @@ const updateIdentityProvider = async (orgID, idpData) => {
                 ...(idpData.certificate && { CERTIFICATE: idpData.certificate })
             },
             {
-                where: {
-                    ORG_ID: orgID
-                },
-                returning: true
+                where: { ORG_ID: orgID },
+                returning: true,
+                transaction: t,
             }
         );
         if (updatedRowsCount < 1) {

--- a/src/dao/apiMetadata.js
+++ b/src/dao/apiMetadata.js
@@ -116,7 +116,7 @@ const createLabels = async (orgID, labels, t) => {
     }
 }
 
-const updateLabel = async (orgID, label) => {
+const updateLabel = async (orgID, label, t) => {
 
     try {
         let [record, created] = await Labels.findOrCreate({
@@ -128,10 +128,11 @@ const updateLabel = async (orgID, label) => {
                 NAME: label.name,
                 DISPLAY_NAME: label.displayName,
             },
+            transaction: t,
             returning: true
         });
         if (!created) {
-            record = await record.update(label); // Update if found
+            record = await record.update(label, { transaction: t }); // Update if found
         }
         return record;
     } catch (error) {
@@ -375,6 +376,20 @@ const addLabel = async (orgID, labelID, viewID, t) => {
             ORG_ID: orgID
         }, { transaction: t });
         return labelResponse;
+    } catch (error) {
+        if (error instanceof Sequelize.UniqueConstraintError) {
+            throw error;
+        }
+        throw new Sequelize.DatabaseError(error);
+    }
+}
+
+const replaceViewLabels = async (orgID, viewID, labelNames, t) => {
+    try {
+        await ViewLabels.destroy({ where: { VIEW_ID: viewID, ORG_ID: orgID }, transaction: t });
+        if (labelNames?.length) {
+            await addViewLabels(orgID, viewID, labelNames, t);
+        }
     } catch (error) {
         if (error instanceof Sequelize.UniqueConstraintError) {
             throw error;
@@ -1893,6 +1908,7 @@ module.exports = {
     getLabels,
     addView,
     addViewLabels,
+    replaceViewLabels,
     deleteViewLabels,
     updateView,
     deleteView,

--- a/src/dao/apiMetadata.js
+++ b/src/dao/apiMetadata.js
@@ -245,7 +245,7 @@ const updateView = async (orgID, name, displayName, t) => {
             record = await record.update({
                 NAME: name,
                 DISPLAY_NAME: displayName,
-            }); // Update if found
+            }, { transaction: t }); // Update if found
         }
         return record;
     } catch (error) {
@@ -391,7 +391,7 @@ const replaceViewLabels = async (orgID, viewID, labelNames, t) => {
             await addViewLabels(orgID, viewID, labelNames, t);
         }
     } catch (error) {
-        if (error instanceof Sequelize.UniqueConstraintError) {
+        if (error instanceof Sequelize.UniqueConstraintError || error instanceof CustomError) {
             throw error;
         }
         throw new Sequelize.DatabaseError(error);

--- a/src/routes/devportalRoute.js
+++ b/src/routes/devportalRoute.js
@@ -41,14 +41,14 @@ const apiKeyController = require('../controllers/apiKeyController');
 const apiFlowService = require('../services/apiFlowService');
 const webhookAdminController = require('../controllers/webhookAdminController');
 
-router.post('/organizations', enforceSecuirty(constants.SCOPES.ADMIN), adminService.createOrganization);
+router.post('/organizations', enforceSecuirty(constants.SCOPES.ADMIN), multipartHandler.fields([{ name: 'organization', maxCount: 1 }]), adminService.createOrganization);
 router.get('/organizations', enforceSecuirty(constants.SCOPES.ADMIN), adminService.getOrganizations);
-router.put('/organizations/:orgId', enforceSecuirty(constants.SCOPES.ADMIN), adminService.updateOrganization);
+router.put('/organizations/:orgId', enforceSecuirty(constants.SCOPES.ADMIN), multipartHandler.fields([{ name: 'organization', maxCount: 1 }]), adminService.updateOrganization);
 router.get('/organizations/:orgId', enforceSecuirty(constants.SCOPES.ADMIN), devportalService.getOrganization); // S2S Applied 
 router.delete('/organizations/:orgId', enforceSecuirty(constants.SCOPES.ADMIN), adminService.deleteOrganization);
 
-router.post('/organizations/:orgId/identityProvider', enforceSecuirty(constants.SCOPES.ADMIN), adminService.createIdentityProvider);
-router.put('/organizations/:orgId/identityProvider', enforceSecuirty(constants.SCOPES.ADMIN), adminService.updateIdentityProvider);
+router.post('/organizations/:orgId/identityProvider', enforceSecuirty(constants.SCOPES.ADMIN), multipartHandler.fields([{ name: 'identityProvider', maxCount: 1 }]), adminService.createIdentityProvider);
+router.put('/organizations/:orgId/identityProvider', enforceSecuirty(constants.SCOPES.ADMIN), multipartHandler.fields([{ name: 'identityProvider', maxCount: 1 }]), adminService.updateIdentityProvider);
 router.get('/organizations/:orgId/identityProvider', enforceSecuirty(constants.SCOPES.ADMIN), adminService.getIdentityProvider);
 router.delete('/organizations/:orgId/identityProvider', enforceSecuirty(constants.SCOPES.ADMIN), adminService.deleteIdentityProvider);
 

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -73,6 +73,22 @@ function parseOrganizationFromYamlFile(fileBuffer) {
             `Unknown organization YAML kind '${parsed.kind}'. Expected 'Organization'`
         );
     }
+    const { spec = {} } = parsed;
+    if (spec.labels !== undefined && spec.labels !== null) {
+        if (!Array.isArray(spec.labels) || spec.labels.some(l => typeof l !== 'object' || !l.name)) {
+            throw new Sequelize.ValidationError("Invalid organization YAML: 'spec.labels' must be an array of objects with a 'name' field");
+        }
+    }
+    if (spec.views !== undefined && spec.views !== null) {
+        if (!Array.isArray(spec.views) || spec.views.some(v => typeof v !== 'object' || !v.name)) {
+            throw new Sequelize.ValidationError("Invalid organization YAML: 'spec.views' must be an array of objects with a 'name' field");
+        }
+    }
+    if (spec.identityProvider !== undefined && spec.identityProvider !== null) {
+        if (typeof spec.identityProvider !== 'object' || Array.isArray(spec.identityProvider)) {
+            throw new Sequelize.ValidationError("Invalid organization YAML: 'spec.identityProvider' must be an object");
+        }
+    }
     return mapYamlToOrganization(parsed);
 }
 
@@ -196,13 +212,12 @@ const createOrganization = async (req, res) => {
             logger.info('Default subscription policies created successfully', {
                 orgId
             });
-        });
 
-        // IDP creation runs outside the transaction (DAO does not support transaction param)
-        if (payload.identityProvider) {
-            await adminDao.createIdentityProvider(organization.ORG_ID, payload.identityProvider);
-            logger.info('Identity provider created successfully', { orgId: organization.ORG_ID });
-        }
+            if (payload.identityProvider) {
+                await adminDao.createIdentityProvider(orgId, payload.identityProvider, t);
+                logger.info('Identity provider created successfully', { orgId });
+            }
+        });
 
         const orgCreationResponse = {
             orgId: organization.ORG_ID,
@@ -297,35 +312,42 @@ const updateOrganization = async (req, res) => {
         }
         const payload = req.body;
         payload.orgId = orgId;
-        const [, updatedOrg] = await adminDao.updateOrganization(payload);
-        logger.info('Organization update successful', { orgId });
 
-        // IDP upsert — only if present in payload
-        if (payload.identityProvider) {
-            const existing = await adminDao.getIdentityProvider(orgId);
-            if (existing.length > 0) {
-                await adminDao.updateIdentityProvider(orgId, payload.identityProvider);
-            } else {
-                await adminDao.createIdentityProvider(orgId, payload.identityProvider);
-            }
-            logger.info('Identity provider upserted successfully', { orgId });
-        }
+        let updatedOrg;
+        await sequelize.transaction({ timeout: 60000 }, async (t) => {
+            [, updatedOrg] = await adminDao.updateOrganization(payload, t);
+            logger.info('Organization update successful', { orgId });
 
-        // Labels upsert — only if present in payload
-        if (payload.labels?.length) {
-            for (const label of payload.labels) {
-                await apiDao.updateLabel(orgId, label);
+            // IDP upsert — only if present in payload
+            if (payload.identityProvider) {
+                const existing = await adminDao.getIdentityProvider(orgId);
+                if (existing.length > 0) {
+                    await adminDao.updateIdentityProvider(orgId, payload.identityProvider, t);
+                } else {
+                    await adminDao.createIdentityProvider(orgId, payload.identityProvider, t);
+                }
+                logger.info('Identity provider upserted successfully', { orgId });
             }
-            logger.info('Labels upserted successfully', { orgId });
-        }
 
-        // Views upsert — only if present in payload
-        if (payload.views?.length) {
-            for (const viewDef of payload.views) {
-                await apiDao.updateView(orgId, viewDef.name, viewDef.displayName);
+            // Labels upsert — only if present in payload
+            if (payload.labels?.length) {
+                for (const label of payload.labels) {
+                    await apiDao.updateLabel(orgId, label, t);
+                }
+                logger.info('Labels upserted successfully', { orgId });
             }
-            logger.info('Views upserted successfully', { orgId });
-        }
+
+            // Views upsert — only if present in payload
+            if (payload.views?.length) {
+                for (const viewDef of payload.views) {
+                    const view = await apiDao.updateView(orgId, viewDef.name, viewDef.displayName, t);
+                    if (viewDef.labels?.length) {
+                        await apiDao.replaceViewLabels(orgId, view.dataValues.VIEW_ID, viewDef.labels, t);
+                    }
+                }
+                logger.info('Views upserted successfully', { orgId });
+            }
+        });
 
         res.status(200).json({
             orgId: updatedOrg[0].dataValues.ORG_ID,

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -37,7 +37,90 @@ const yaml = require('js-yaml');
 const { Sequelize } = require("sequelize");
 const { trackGenerateCredentials, trackSubscribeApi, trackUnsubscribeApi } = require('../utils/telemetry');
 
+function mapYamlToOrganization(parsed) {
+    const { metadata = {}, spec = {} } = parsed;
+    return {
+        orgHandle: metadata.name,
+        orgName: spec.displayName,
+        organizationIdentifier: spec.organizationIdentifier,
+        businessOwner: spec.businessOwner,
+        businessOwnerContact: spec.businessOwnerContact,
+        businessOwnerEmail: spec.businessOwnerEmail,
+        roleClaimName: spec.roleClaimName,
+        organizationClaimName: spec.organizationClaimName,
+        groupsClaimName: spec.groupsClaimName,
+        adminRole: spec.adminRole,
+        subscriberRole: spec.subscriberRole,
+        superAdminRole: spec.superAdminRole,
+        identityProvider: spec.identityProvider || null,
+        labels: spec.labels || null,
+        views: spec.views || null,
+    };
+}
+
+function parseOrganizationFromYamlFile(fileBuffer) {
+    let parsed;
+    try {
+        parsed = yaml.load(fileBuffer.toString(constants.CHARSET_UTF8));
+    } catch (e) {
+        throw new Sequelize.ValidationError(`Invalid organization YAML file: ${e.message}`);
+    }
+    if (!parsed || typeof parsed !== 'object') {
+        throw new Sequelize.ValidationError('Organization YAML file is empty or invalid');
+    }
+    if (parsed.kind !== 'Organization') {
+        throw new Sequelize.ValidationError(
+            `Unknown organization YAML kind '${parsed.kind}'. Expected 'Organization'`
+        );
+    }
+    return mapYamlToOrganization(parsed);
+}
+
+function mapYamlToIdentityProvider(parsed) {
+    const { metadata = {}, spec = {} } = parsed;
+    return {
+        name: metadata.name,
+        issuer: spec.issuer,
+        authorizationURL: spec.authorizationURL,
+        tokenURL: spec.tokenURL,
+        userInfoURL: spec.userInfoURL,
+        clientId: spec.clientId,
+        callbackURL: spec.callbackURL,
+        scope: spec.scope,
+        signUpURL: spec.signUpURL,
+        logoutURL: spec.logoutURL,
+        logoutRedirectURI: spec.logoutRedirectURI,
+        jwksURL: spec.jwksURL,
+        certificate: spec.certificate,
+    };
+}
+
+function parseIdentityProviderFromYamlFile(fileBuffer) {
+    let parsed;
+    try {
+        parsed = yaml.load(fileBuffer.toString(constants.CHARSET_UTF8));
+    } catch (e) {
+        throw new Sequelize.ValidationError(`Invalid identity provider YAML file: ${e.message}`);
+    }
+    if (!parsed || typeof parsed !== 'object') {
+        throw new Sequelize.ValidationError('Identity provider YAML file is empty or invalid');
+    }
+    if (parsed.kind !== 'IdentityProvider') {
+        throw new Sequelize.ValidationError(
+            `Unknown YAML kind '${parsed.kind}'. Expected 'IdentityProvider'`
+        );
+    }
+    return mapYamlToIdentityProvider(parsed);
+}
+
 const createOrganization = async (req, res) => {
+    if (req.files?.organization?.[0]) {
+        try {
+            req.body = parseOrganizationFromYamlFile(req.files.organization[0].buffer);
+        } catch (error) {
+            return util.handleError(res, error);
+        }
+    }
     logger.info('Initiate organization creation...', req.body);
 
     const rules = util.validateOrganization();
@@ -72,21 +155,34 @@ const createOrganization = async (req, res) => {
                 orgName: organization.ORG_NAME
             });
 
-            // create default label
-            const labels = await apiDao.createLabels(organization.ORG_ID, [{ name: 'default', displayName: 'default' }], t);
-            const labelId = labels[0].dataValues.LABEL_ID;
-            logger.info('Default label created successfully', {
-                orgId
-            });
+            // Labels: use YAML-defined if provided, else fall back to default
+            const labelDefs = payload.labels?.length
+                ? payload.labels
+                : [{ name: 'default', displayName: 'default' }];
 
-            //create default view
-            const viewResponse = await apiDao.addView(orgId, { name: 'default', displayName: 'default' }, t);
-            const viewID = viewResponse.dataValues.VIEW_ID;
-            logger.info('Default view created successfully', {
-                orgId
-            });
+            const createdLabels = await apiDao.createLabels(orgId, labelDefs, t);
+            logger.info('Labels created successfully', { orgId });
 
-            await apiDao.addLabel(orgId, labelId, viewID, t);
+            // Build name→ID map for view→label linking
+            const labelMap = {};
+            createdLabels.forEach(l => { labelMap[l.dataValues.NAME] = l.dataValues.LABEL_ID; });
+
+            // Views: use YAML-defined if provided, else fall back to default
+            const viewDefs = payload.views?.length
+                ? payload.views
+                : [{ name: 'default', displayName: 'default', labels: [labelDefs[0].name] }];
+
+            for (const viewDef of viewDefs) {
+                const viewResponse = await apiDao.addView(orgId, viewDef, t);
+                const viewID = viewResponse.dataValues.VIEW_ID;
+                for (const lName of (viewDef.labels || [])) {
+                    const labelId = labelMap[lName];
+                    if (labelId) {
+                        await apiDao.addLabel(orgId, labelId, viewID, t);
+                    }
+                }
+            }
+            logger.info('Views created successfully', { orgId });
             //create default provider
             await adminDao.createProvider(organization.ORG_ID, { name: 'WSO2', providerURL: config.controlPlane.url }, t);
             logger.info('Default provider created successfully', {
@@ -101,6 +197,12 @@ const createOrganization = async (req, res) => {
                 orgId
             });
         });
+
+        // IDP creation runs outside the transaction (DAO does not support transaction param)
+        if (payload.identityProvider) {
+            await adminDao.createIdentityProvider(organization.ORG_ID, payload.identityProvider);
+            logger.info('Identity provider created successfully', { orgId: organization.ORG_ID });
+        }
 
         const orgCreationResponse = {
             orgId: organization.ORG_ID,
@@ -169,6 +271,13 @@ const getAllOrganizations = async () => {
 
 const updateOrganization = async (req, res) => {
     const orgId = req.params.orgId;
+    if (req.files?.organization?.[0]) {
+        try {
+            req.body = parseOrganizationFromYamlFile(req.files.organization[0].buffer);
+        } catch (error) {
+            return util.handleError(res, error);
+        }
+    }
     logger.info('Initiate update organization...', {
         orgId,
         ...req.body
@@ -189,9 +298,35 @@ const updateOrganization = async (req, res) => {
         const payload = req.body;
         payload.orgId = orgId;
         const [, updatedOrg] = await adminDao.updateOrganization(payload);
-        logger.info('Organization update successful', {
-            orgId
-        });
+        logger.info('Organization update successful', { orgId });
+
+        // IDP upsert — only if present in payload
+        if (payload.identityProvider) {
+            const existing = await adminDao.getIdentityProvider(orgId);
+            if (existing.length > 0) {
+                await adminDao.updateIdentityProvider(orgId, payload.identityProvider);
+            } else {
+                await adminDao.createIdentityProvider(orgId, payload.identityProvider);
+            }
+            logger.info('Identity provider upserted successfully', { orgId });
+        }
+
+        // Labels upsert — only if present in payload
+        if (payload.labels?.length) {
+            for (const label of payload.labels) {
+                await apiDao.updateLabel(orgId, label);
+            }
+            logger.info('Labels upserted successfully', { orgId });
+        }
+
+        // Views upsert — only if present in payload
+        if (payload.views?.length) {
+            for (const viewDef of payload.views) {
+                await apiDao.updateView(orgId, viewDef.name, viewDef.displayName);
+            }
+            logger.info('Views upserted successfully', { orgId });
+        }
+
         res.status(200).json({
             orgId: updatedOrg[0].dataValues.ORG_ID,
             orgName: updatedOrg[0].dataValues.ORG_NAME,
@@ -248,6 +383,13 @@ const deleteOrganization = async (req, res) => {
 
 const createIdentityProvider = async (req, res) => {
     const orgId = req.params.orgId;
+    if (req.files?.identityProvider?.[0]) {
+        try {
+            req.body = parseIdentityProviderFromYamlFile(req.files.identityProvider[0].buffer);
+        } catch (error) {
+            return util.handleError(res, error);
+        }
+    }
     logger.info('Initiate create identity provider...', {
         orgId,
         ...req.body
@@ -282,6 +424,13 @@ const createIdentityProvider = async (req, res) => {
 
 const updateIdentityProvider = async (req, res) => {
     const orgId = req.params.orgId;
+    if (req.files?.identityProvider?.[0]) {
+        try {
+            req.body = parseIdentityProviderFromYamlFile(req.files.identityProvider[0].buffer);
+        } catch (error) {
+            return util.handleError(res, error);
+        }
+    }
     const idpData = req.body;
     logger.info('Initiate update identity provider...', {
         orgId,


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2-enterprise/apim-saas/issues/2605

## Approach
Added YAML file upload support for organizations and identity providers, bringing them in line with the existing YAML support for APIs, apps, and subscription policies. JSON body requests are unchanged.

For organizations, metadata.name maps to orgHandle (the URL slug) and spec.displayName maps to orgName (the human-readable name), consistent with how other resource YAMLs use metadata.name as the machine identifier. The YAML can optionally inline identityProvider, labels, and views to configure those in a single request rather than requiring separate follow-up calls.

The OrganizationCreateBody, OrganizationUpdateBody, and IdentityProviderBody request bodies in the OpenAPI spec are updated to document the multipart/form-data content type alongside the existing JSON entries.


## Examples

**Create an organization from YAML:**
```bash
curl -X POST /devportal/organizations \
  -F "organization=@org.yaml"
```

**`org.yaml`:**
```yaml
apiVersion: devportal.api-platform.wso2.com/v1
kind: Organization

metadata:
  name: ACME

spec:
  displayName: ACME
  organizationIdentifier: ACME
  adminRole: admin
  subscriberRole: subscriber
  superAdminRole: superAdmin

  identityProvider:
    name: IS
    issuer: https://localhost:9443/oauth2/token
    authorizationURL: https://localhost:9443/oauth2/authorize
    tokenURL: https://localhost:9443/oauth2/token
    clientId: ""
    callbackURL: http://localhost:3000/ACME/callback
    scope: "openid profile"

  labels:
    - name: default
      displayName: Default

  views:
    - name: default
      displayName: Default View
      labels:
        - default
```


**Create an identity provider from YAML:**
```bash
curl -X POST /devportal/organizations/{orgId}/identityProvider \
  -F "identityProvider=@idp.yaml"
```

**`idp.yaml`:**
```yaml
apiVersion: devportal.api-platform.wso2.com/v1
kind: IdentityProvider

metadata:
  name: IS

spec:
  issuer: https://localhost:9443/oauth2/token
  authorizationURL: https://localhost:9443/oauth2/authorize
  tokenURL: https://localhost:9443/oauth2/token
  userInfoURL: https://localhost:9443/oauth2/userinfo
  clientId: ""
  callbackURL: http://localhost:3000/ACME/callback
  scope: "openid profile"
  logoutURL: https://localhost:9443/oidc/logout
  logoutRedirectURI: http://localhost:3000/ACME
  jwksURL: https://localhost:9443/oauth2/jwks
  certificate: ""
```